### PR TITLE
Openldap indices

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Dejan Menges, HCL
 Sabrina Yee, HCL
 Ujjawal Khare, HCL
+Christoph Stoettner, Vegard IT

--- a/roles/third_party/ldap-install/templates/db.ldif.j2
+++ b/roles/third_party/ldap-install/templates/db.ldif.j2
@@ -12,3 +12,13 @@ dn: olcDatabase={2}hdb,cn=config
 changetype: modify
 replace: olcRootPW
 olcRootPW: {{ slappasswd_output['stdout'] }}
+
+dn: olcDatabase={2}hdb,cn=config
+changetype: modify
+replace: olcDbIndex
+olcDbIndex: objectclass eq,pres
+
+dn: olcDatabase={2}hdb,cn=config
+changetype: modify
+add: olcDbIndex
+olcDbIndex: uid,ou,cn,mail,sn eq,pres,sub


### PR DESCRIPTION
Hi,
I started comparing the Ansible roles with the ones I wrote for 6.5 in the moment. First of all thanks for sharing.

I had issues with my OpenLDAP server during Loadtesting with jmeter (after around 20 users the logins started to fail) and during troubleshooting I found that the default indices for OpenLDAP do not index uid ( I added cn, mail and sn too). Adding the index during the LDAP server setup is easy, so I added my findings here. 

Regards
Christoph