### PR TITLE
Remote user configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ Of course, you can drop it all to a single folder, or restructure it whatever wa
 
 Inventory files live in environments folder. In general all the variables are separated in two files - connections and component_pack. It could be merged of course, as lot of stuff is overlapping, but be careful if merging not to overlap stuff that eventually shouldn't be (like if you are using different NFSs for the WebSphere-side of Connections and Component Pack).
 
+### SSH User
+
+If you run the Ansible playbooks from a Mac or Linux host, you need to specify the `remote_user` for the SSH connection, or it will default to your local username.
+
+Edit `ansible.cfg` and remove the comment `#` from the line and set your user:
+
+    # remote_user = root
+
+Example:
+
+    remote_user = sysadmin
+
+The `ansible.cfg` allows a lot of settings, see the example file at https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg and it can stay in the root of your Ansible project, or can be placed in `~/.ansible.cfg`, then it will work for all of your Ansible projects.
+
 ### Supported layouts
 
 Those scripts should be able to support both single node installations and HA environments, specifically:

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+# Find more configuration options in the example ansible.cfg on https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg
+[defaults]
+# default user to use for playbooks if user is not specified
+# # (/usr/bin/ansible will use current user as default)
+# #remote_user = root


### PR DESCRIPTION
I added an example ansible.cfg, so you can set Ansible configuration parameters as a default, like the remote_user which can be set on the commandline (but you need to remember each time), or on project base in the root directory of the Ansible project.