### PR TITLE
add nfs option to playbook

### DIFF
--- a/playbooks/setup-connections-complete.yml
+++ b/playbooks/setup-connections-complete.yml
@@ -1,6 +1,9 @@
 - name:                  Setup DB2
   import_playbook:       third_party/setup-db2.yml
 
+- name:                  Setup NFS
+  import_playbook:       third_party/setup-nfs.yml
+
 - name:                  Setup Connections Wizards
   import_playbook:       hcl/setup-connections-wizards.yml
 


### PR DESCRIPTION
setup-connections-complete.yml has no NFS configured, so the installation of Connections fails. Added the role to the playbook.

Maybe it would be an idea to use tags for NFS config. So that in an environment without Componentpack the pv-connections share get not configured? But that's not really necessary, just an idea.