### PR TITLE
missing db2 directory for appGrants.sql

### DIFF
--- a/roles/hcl/connections-wizards/tasks/setup_connections_docs.yml
+++ b/roles/hcl/connections-wizards/tasks/setup_connections_docs.yml
@@ -79,7 +79,7 @@
     - not docs_migrations_already_done.stat.exists
 
 - name:                  Run appGrants.sql
-  shell:                 "{{ __db2_migration_cmd }} {{ __docs_installation_folder }}/{{ item }}"
+  shell:                 "{{ __db2_migration_cmd }} {{ __docs_installation_folder }}/db2/{{ item }}"
   register:              result
   failed_when:           ( result.rc not in [0, 1, 2, 3] )
   become_user:           "{{ __db2_user }}"


### PR DESCRIPTION
AppGrants runs into an error, because the file is missing. Checked the extracted source and it is based in a subfolder db2. Added this here and playbook runs through then.