### PR TITLE
jdbc files not needed when deploying cnx with db2

### DIFF
--- a/roles/third_party/oracle-install/tasks/main.yml
+++ b/roles/third_party/oracle-install/tasks/main.yml
@@ -27,4 +27,5 @@
   include_tasks:                   install_jdbc.yml
   when:
     - "'was_servers' in group_names"
+    - "'oracle_servers' in group_names"
     - inventory_hostname in groups["was_servers"]


### PR DESCRIPTION
Even after commenting out the oracle playbook in the connections_complete playbook, the websphere installation tried to unpack oracle jdbc files. Adding this when statement, this prevents the extraction and the playbook runs through.