### PR TITLE
replace hardcoded maildomain with variable

### DIFF
--- a/roles/third_party/ldap-install/templates/users.ldif.j2
+++ b/roles/third_party/ldap-install/templates/users.ldif.j2
@@ -4,14 +4,14 @@ objectClass: top
 dc: {{ __ldap_tld }}
 
 
-dn: uid={{ __ldap_userid }}1,{{ __ldap_olc_suffix }}
+dn: uid={{ __ldap_admin_user }}1,{{ __ldap_olc_suffix }}
 objectClass: inetOrgPerson
 objectClass: top
 cn: Joe Jones1
 sn: Jones1
 givenName: Joe
-mail: {{ __ldap_userid }}1@{{ __ldap_user_mail_domain }}
-uid: {{ __ldap_userid }}1
+mail: {{ __ldap_admin_user }}1@{{ __ldap_user_mail_domain }}
+uid: {{ __ldap_admin_user }}
 description: I am interested in Robotics; I play Hockey and Soccer
 userPassword: {{ __ldap_user_admin_password }}
 telephoneNumber: 1-978-399-0000
@@ -52,7 +52,7 @@ objectClass: top
 cn: Joe Jones{{ counter }}
 sn: Jones{{ counter }}
 givenName: Joe
-mail: {{ __ldap_userid }}{{ counter }}@connections.example.com
+mail: {{ __ldap_userid }}{{ counter }}@{{ __ldap_user_mail_domain }}
 uid: {{ __ldap_userid }}{{ counter }}
 description: I am interested in Robotics; I play Hockey and Soccer
 userPassword: {{ __ldap_user_password }}

--- a/roles/third_party/ldap-install/templates/users.ldif.j2
+++ b/roles/third_party/ldap-install/templates/users.ldif.j2
@@ -4,14 +4,14 @@ objectClass: top
 dc: {{ __ldap_tld }}
 
 
-dn: uid={{ __ldap_user }}1,{{ __ldap_olc_suffix }}
+dn: uid={{ __ldap_userid }}1,{{ __ldap_olc_suffix }}
 objectClass: inetOrgPerson
 objectClass: top
 cn: Joe Jones1
 sn: Jones1
 givenName: Joe
-mail: {{ __ldap_user }}1@{{ __ldap_user_mail_domain }}
-uid: {{ __ldap_user }}1
+mail: {{ __ldap_userid }}1@{{ __ldap_user_mail_domain }}
+uid: {{ __ldap_user_password }}1
 description: I am interested in Robotics; I play Hockey and Soccer
 userPassword: {{ __ldap_user_password }}
 telephoneNumber: 1-978-399-0000

--- a/roles/third_party/ldap-install/templates/users.ldif.j2
+++ b/roles/third_party/ldap-install/templates/users.ldif.j2
@@ -11,7 +11,7 @@ cn: Joe Jones1
 sn: Jones1
 givenName: Joe
 mail: {{ __ldap_userid }}1@{{ __ldap_user_mail_domain }}
-uid: {{ __ldap_user_password }}1
+uid: {{ __ldap_userid }}1
 description: I am interested in Robotics; I play Hockey and Soccer
 userPassword: {{ __ldap_user_password }}
 telephoneNumber: 1-978-399-0000

--- a/roles/third_party/ldap-install/templates/users.ldif.j2
+++ b/roles/third_party/ldap-install/templates/users.ldif.j2
@@ -4,16 +4,16 @@ objectClass: top
 dc: {{ __ldap_tld }}
 
 
-dn: uid={{ __ldap_admin_user }}1,{{ __ldap_olc_suffix }}
+dn: uid={{ __ldap_user }}1,{{ __ldap_olc_suffix }}
 objectClass: inetOrgPerson
 objectClass: top
 cn: Joe Jones1
 sn: Jones1
 givenName: Joe
-mail: {{ __ldap_admin_user }}1@{{ __ldap_user_mail_domain }}
-uid: {{ __ldap_admin_user }}
+mail: {{ __ldap_user }}1@{{ __ldap_user_mail_domain }}
+uid: {{ __ldap_user }}1
 description: I am interested in Robotics; I play Hockey and Soccer
-userPassword: {{ __ldap_user_admin_password }}
+userPassword: {{ __ldap_user_password }}
 telephoneNumber: 1-978-399-0000
 employeeType: internal
 


### PR DESCRIPTION
Maildomain for demo LDAP Users was hardcoded in the jinga2 template, replaced it with the already defined variable.

Additionally replaced the admin user variables like it was intentionally thought (or better I think it was). The variables in inventory let you define ldap_admin userid and password, but it is not used in the template.