### PR TITLE
Bugfix/semanage prerequisits

### DIFF
--- a/roles/third_party/nginx-install/handlers/main.yml
+++ b/roles/third_party/nginx-install/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: reboot
+  reboot:
+    msg: "Reboot initiated from Ansible"
+    connect_timeout: 30
+    reboot_timeout: 120
+    test_command: whoami

--- a/roles/third_party/nginx-install/tasks/setup_os.yml
+++ b/roles/third_party/nginx-install/tasks/setup_os.yml
@@ -14,10 +14,19 @@
   when:
    - ansible_distribution == "RedHat"
 
+- name:                     Install prerequisits for semanage
+  package:
+    name:                   "{{ item }}"
+    state:                  present
+  with_items:
+    - libselinux-python
+    - libsemanage-python
+
 - name:                     Disable SELinux
   selinux:
     state:                  disabled
   ignore_errors:            true
+  notify:                   reboot
 
 - name:                     Set httpd_can_network_connect flag on and keep it persistent across reboots
   seboolean:


### PR DESCRIPTION
Add handler for rebooting machine if selinux state changes (needs to be implemented on mulitple roles).

Add prerequisits for seboolean module, had errors on a Centos7 minimal, this is fixed with that.