### PR TITLE
replace group names (typos)

### DIFF
--- a/playbooks/third_party/kubernetes/add-worker.yml
+++ b/playbooks/third_party/kubernetes/add-worker.yml
@@ -25,7 +25,7 @@
     - roles/third_party/kubernetes/setup-worker-node
 
 - name:                    Taint nodes
-  hosts:                   k8s_master, k8s_workers
+  hosts:                   k8s_masters, k8s_workers
   become:                  true
   roles:
     - roles/third_party/kubernetes/taint-all-nodes

--- a/playbooks/third_party/kubernetes/setup-kubernetes.yml
+++ b/playbooks/third_party/kubernetes/setup-kubernetes.yml
@@ -45,7 +45,7 @@
     - roles/third_party/kubernetes/setup-worker-node
 
 - name:                    Allow pods to run on master in case of single node installation
-  hosts:                   k8s_master, k8s_workers
+  hosts:                   k8s_masters, k8s_workers
   become:                  true
   roles:
     - roles/third_party/kubernetes/taint-all-nodes


### PR DESCRIPTION
There are typos in the group names, made them consistent to inventory