### PR TITLE
remove trailing s after when clause to prevent error

### DIFF
--- a/roles/third_party/ibm/ihs/ibm-http-adminctl-start/tasks/main.yml
+++ b/roles/third_party/ibm/ihs/ibm-http-adminctl-start/tasks/main.yml
@@ -15,7 +15,7 @@
   shell:         ps -p `cat "{{ __ihs_install_location }}/logs/admin.pid"`
   register:      ihs_is_running
   ignore_errors: true
-  when:          (ihs_start.rc is defined) and (ihs_start.rc == 0)s
+  when:          (ihs_start.rc is defined) and (ihs_start.rc == 0)
 
 - name:          Wait 10 seconds for AdminCtl to activate
   pause:

--- a/roles/third_party/ibm/ihs/ibm-http-server-restart/tasks/main.yml
+++ b/roles/third_party/ibm/ihs/ibm-http-server-restart/tasks/main.yml
@@ -31,7 +31,7 @@
   shell:         ps -p `cat "{{ __ihs_install_location }}/logs/httpd.pid"`
   register:      ihs_is_running
   ignore_errors: true
-  when:          (ihs_start.rc is defined) and (ihs_start.rc == 0)s
+  when:          (ihs_start.rc is defined) and (ihs_start.rc == 0)
 
 - name:          Wait 10 seconds for ihs to activate
   pause:

--- a/roles/third_party/ibm/ihs/ibm-http-server-start/tasks/main.yml
+++ b/roles/third_party/ibm/ihs/ibm-http-server-start/tasks/main.yml
@@ -15,7 +15,7 @@
   shell:         ps -p `cat "{{ __ihs_install_location }}/logs/httpd.pid"`
   register:      ihs_is_running
   ignore_errors: true
-  when:          (ihs_start.rc is defined) and (ihs_start.rc == 0)s
+  when:          (ihs_start.rc is defined) and (ihs_start.rc == 0)
 
 - name:          Wait 10 seconds for ihs to activate
   pause:

--- a/roles/third_party/ibm/wasnd/was-dmgr-restart/tasks/main.yml
+++ b/roles/third_party/ibm/wasnd/was-dmgr-restart/tasks/main.yml
@@ -30,7 +30,7 @@
   shell:         "ps -p `cat '{{ __was_install_location }}/profiles/{{ __profile_name }}/logs/dmgr/dmgr.pid'` > /dev/null"
   register:      dmgr_is_running
   ignore_errors: true
-  when:          (dmgr_start.rc is defined) and (dmgr_start.rc == 0)s
+  when:          (dmgr_start.rc is defined) and (dmgr_start.rc == 0)
 
 - name:          Wait 60 seconds for DMGR to activate
   pause:


### PR DESCRIPTION
When clauses of these 4 files have a trailing s and generate errors:

"The conditional check '(dmgr_start.rc is defined) and (dmgr_start.rc == 0)s' failed. The error was: template error while templating string: expected token 'end of statement block', got 's'.