### PR TITLE
es-metrics certs copy fix

### DIFF
--- a/roles/hcl/component-pack/tasks/enable_es_metrics.yml
+++ b/roles/hcl/component-pack/tasks/enable_es_metrics.yml
@@ -57,11 +57,17 @@
     format:                  zip
   become:                    false
 
-- name:                      Copy {{ __es_certs_dir_temp }}.zip to {{ dmgr_hostname }}
-  synchronize: 
+- name:                      Copy {{ __es_certs_dir_temp }}.zip to local
+  fetch:
     src:                     "{{ __es_certs_dir_temp }}.zip"
-    dest:                    /tmp
-    mode:                    pull
+    dest:                    "{{ __es_certs_dir_temp }}.zip"
+    flat:                    yes
+  become:                    false
+
+- name:                      Copy {{ __es_certs_dir_temp }}.zip to {{ dmgr_hostname }}
+  copy:
+    src:                     "{{ __es_certs_dir_temp }}.zip"
+    dest:                    "{{ __es_certs_dir_temp }}.zip"
   delegate_to:               "{{ dmgr_hostname }}"
   become:                    false
 


### PR DESCRIPTION
The synchronise fails. rsync is not able to run between these servers (master <-> dmgr) without configuring additional trust etc. It is better to use the Ansible server as temp space as it is already able to connect/trust each.