### PR TITLE
ANSIBLE to support K8s installation on RedHat and CentOS - Install pre-req plus Removing SUSE Repo and related VARS

### DIFF
--- a/roles/third_party/kubernetes/kubernetes-install/tasks/prepare_for_k8s.yml
+++ b/roles/third_party/kubernetes/kubernetes-install/tasks/prepare_for_k8s.yml
@@ -28,7 +28,7 @@
     src:             "{{ __kubernetes_yum_repo_template }}"
     dest:            "{{ __kubernetes_yum_repo_location }}"
   when:
-   - ansible_distribution == "RedHat"
+   - ansible_os_family == "RedHat"
    - ansible_distribution_major_version == "7"
 
 - name:              Enable Kubernetes repository
@@ -36,7 +36,7 @@
     src:             "{{ __kubernetes_yum_rhel8_template }}"
     dest:            "{{ __kubernetes_yum_repo_location }}"
   when:
-   - ansible_distribution == "RedHat"
+   - ansible_os_family == "RedHat"
    - ansible_distribution_major_version == "8"
 
 - name:              Install prereqs for RHEL 8 / CentOS 8
@@ -44,31 +44,8 @@
     name:            ['iproute-tc']
     state:           present
   when:
-   - ansible_distribution == "RedHat"
+   - ansible_os_family == "RedHat"
    - ansible_distribution_major_version == "8"
-
-- name:              Enable Kubernetes repository on SUSE
-  template:
-    src:             "{{ __kubernetes_zypp_repo_template }}"
-    dest:            "{{ __kubernetes_zypp_repo_location }}"
-  when:
-    - ansible_distribution == "SLES"
-
-- name:              Install pre-requisites Zypper
-  zypper:
-    name:            ['python3', 'selinux-tools', 'libselinux-devel', 'selinux-tools', 'libselinux1', 'python3-selinux']
-# 'kernel-default', 'libnuma1', 'libaio1', 'libstdc++6']
-    state:           present
-  when:
-    - ansible_distribution == "SLES"
-
-- name: Creating selinux config file
-  copy:
-    dest: "/etc/selinux/config"
-    content: |
-      enforcing=1
-  when:
-    - ansible_distribution == "SLES"
 
 - name:              "Load br_netfilter as per https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#letting-iptables-see-bridged-traffic"
   modprobe:

--- a/roles/third_party/kubernetes/kubernetes-install/templates/kubernetes.zypp.repo.j2
+++ b/roles/third_party/kubernetes/kubernetes-install/templates/kubernetes.zypp.repo.j2
@@ -1,8 +1,0 @@
-[kubernetes]
-name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$basearch
-enabled=1
-gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-exclude=kubelet kubeadm kubectl

--- a/roles/third_party/kubernetes/kubernetes-install/vars/main.yml
+++ b/roles/third_party/kubernetes/kubernetes-install/vars/main.yml
@@ -6,9 +6,6 @@ __ansible_cache:                                     "/tmp/k8s_ansible"
 __kubernetes_yum_repo_template:                      "kubernetes.repo.j2"
 __kubernetes_yum_rhel8_template:                     "kubernetes.repo.rhel8.j2"
 __kubernetes_yum_repo_location:                      "/etc/yum.repos.d/kubernetes.repo"
-__kubernetes_zypp_repo_template:                     "kubernetes.zypp.repo.j2"
-__kubernetes_zypp_repo_location:                     "/etc/zypp/repos.d/kubernetes.repo"
-
 __kubelet_systemd_template:                          "etc.sysconfig.kubelet.j2"
 __kubelet_systemd_location:                          "/etc/sysconfig/kubelet"
 


### PR DESCRIPTION
Recently found that :

ANSIBLE is skipping kubernetes.repo configuration for CentOS. This seems due to recent changes made to support RHEL8.


Removed kubernetes installation for SUSE  and related vars, templates from ANSIBLE as Kubernetes installation on SUSE linux is not yet supported in automation and it needs manual intervention.