### PR TITLE
Fix Docs nfs ip resolve issue

### DIFF
--- a/playbooks/hcl/setup-connections-docs.yml
+++ b/playbooks/hcl/setup-connections-docs.yml
@@ -1,5 +1,9 @@
 # Install Docs 2.0.1
 ---
+- name:                    Gather facts
+  hosts:                   nfs_servers
+  tasks:                   []
+
 - name:                    Setup NFS
   hosts:                   conversion_servers, viewer_servers, docs_servers
   become:                  true


### PR DESCRIPTION
Fix for https://github.com/HCL-TECH-SOFTWARE/connections-automation/issues/140.

Issue could be reproduce if NFS server is not one of the Connections nodes.
