### PR TITLE
Change docker service variable

### DIFF
--- a/roles/third_party/docker-install/tasks/setup_docker_registry.yml
+++ b/roles/third_party/docker-install/tasks/setup_docker_registry.yml
@@ -114,7 +114,7 @@
 
 - name:                             Save Docker Registry status
   set_fact:
-    docker_registry_is_running:     "{{ docker_registry_status.ansible_facts.docker_container.State.Running }}"
+    docker_registry_is_running:     "{{ docker_registry_status.container.State.Running }}"
   when:
    - inventory_hostname == groups['docker_registry'][0]
    - ansible_os_family == "RedHat"
@@ -122,7 +122,7 @@
 - name:                             Fail if Docker Registry is not running
   fail:
     msg: "Docker Registry could not be started"
-  when: 
+  when:
    - inventory_hostname == groups['docker_registry'][0]
    - not docker_registry_is_running
 


### PR DESCRIPTION
Docker Registry installation is failing with error:

`
TASK [docker-install : Save Docker Registry status] ************************************************************************************************************************************************************************************
fatal: [cnx65-cp.stoeps.home]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'ansible_facts'
  
    The error appears to be in '/home/stoeps/work/iac/connections-automation/roles/third_party/docker-install/tasks/setup_docker_registry.yml': line 119, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
    - name:                             Save Docker Registry status
      ^ here
`

I think this line is the reason:

https://github.com/HCL-TECH-SOFTWARE/connections-automation/blame/main/roles/third_party/docker-install/tasks/setup_docker_registry.yml#L117

When I print the variable `docker_registry_status` I get:

`
  docker_registry_status:
    changed: true
    container:
      AppArmorProfile: ''
      Args:
      - /etc/docker/registry/config.yml
      ...
      RestartCount: 0
      State:
        ...
        Running: true
        StartedAt: '2021-09-20T12:16:51.785239363Z'
        Status: running
`
So the variable to check is `docker_registry_status.container.State.Running` and not the used `docker_registry_status.ansible_facts.docker_container.State.Running` 

Regards
Christoph
