### PR TITLE
Wait for Pod instead of helm upgrade

### DIFF
--- a/roles/hcl/component-pack/tasks/setup_orientme.yml
+++ b/roles/hcl/component-pack/tasks/setup_orientme.yml
@@ -16,11 +16,11 @@
   become_user:               "{{ __sudo_user }}"
 
 - name:                      Setup orientme
-  command:                   "helm upgrade orientme {{ orientme_tgz.files[0].path }} -i -f {{ __orientme_env }} --namespace {{ __default_namespace }} --wait"
+  command:                   "helm upgrade orientme {{ orientme_tgz.files[0].path }} -i -f {{ __orientme_env }} --namespace {{ __default_namespace }}"
   become_user:               "{{ __sudo_user }}"
 
 - name:                      Wait for people-migrate pod to become ready
-  shell:                     kubectl wait --namespace {{ __default_namespace }} --for=condition=ready pod --selector=app=people-migrate --timeout=300s
+  shell:                     kubectl wait --namespace {{ __default_namespace }} --for=condition=ready pod --selector=app=people-migrate --timeout=600s
   become_user:               "{{ __sudo_user }}"
 
 - name:                      Check if orientme is up and running


### PR DESCRIPTION
Waiting for the helm upgrade causes the chart to be flagged as FAILED in helm2. Remove --wait allows chart to finish installing in its own time, then wait on the pod next instead. Increased timeout instead of using 2.