### PR TITLE
6.5 cr1 deployment

### DIFF
--- a/environments/examples/cnx6/db2/group_vars/all.yml
+++ b/environments/examples/cnx6/db2/group_vars/all.yml
@@ -43,6 +43,7 @@ ihs_fixes_repository_url:                        http://{{ groups['installer'][0
 cnx_docs_download_location:                      http://{{ groups['installer'][0] }}:8001/Docs
 cnx_repository_url:                              http://{{ groups['installer'][0] }}:8001/Connections6.5
 cnx_fixes_url:                                   http://{{ groups['installer'][0] }}:8001/Connections6.5CR1
+cnx_db_updates_url:                              http://{{ groups['installer'][0] }}:8001/cnx65_dbupdates
 component_pack_download_location:                http://{{ groups['installer'][0] }}:8001/cp
 
 # Falling back to the defaults for Connections 6.5.0.1
@@ -75,6 +76,7 @@ cnx_fixes_version:                               "6.5.0.0_CR1"
 cnx_fixes_files:
   - { file_name: "HC6.5_CR1.zip" }
 db_version:                                      "6.5"
+cnx_db_update_file:                              "65cr1-database-updates.zip"
 elasticsearch_default_version:                   "5"
 
 # Globals

--- a/environments/examples/cnx6/db2/group_vars/all.yml
+++ b/environments/examples/cnx6/db2/group_vars/all.yml
@@ -42,6 +42,7 @@ ihs_repository_url:                              http://{{ groups['installer'][0
 ihs_fixes_repository_url:                        http://{{ groups['installer'][0] }}:8001/was855FP16
 cnx_docs_download_location:                      http://{{ groups['installer'][0] }}:8001/Docs
 cnx_repository_url:                              http://{{ groups['installer'][0] }}:8001/Connections6.5
+cnx_fixes_url:                                   http://{{ groups['installer'][0] }}:8001/Connections6.5CR1
 component_pack_download_location:                http://{{ groups['installer'][0] }}:8001/cp
 
 # Falling back to the defaults for Connections 6.5.0.1
@@ -70,6 +71,9 @@ ihs_fp_files:
 cnx_package:                                     "HCL_Connections_6.5_lin.tar"
 connections_wizards_package_name:                "HCL_Connections_6.5_wizards_lin_aix.tar"
 cnx_major_version:                               "6"
+cnx_fixes_version:                               "6.5.0.0_CR1"
+cnx_fixes_files:
+  - { file_name: "HC6.5_CR1.zip" }
 db_version:                                      "6.5"
 elasticsearch_default_version:                   "5"
 

--- a/roles/hcl/connections-wizards/tasks/main.yml
+++ b/roles/hcl/connections-wizards/tasks/main.yml
@@ -34,3 +34,9 @@
   when:
     - __setup_connections_docs |bool
     - "'mssql_servers' in groups"
+
+- name:                       Update database to last version (6.5CR1)
+  include_tasks:              update_connections_db_db2.yml
+  when:
+    - "'db2_servers' in groups"
+    - __cnx_fixes_version == '6.5.0.0_CR1'

--- a/roles/hcl/connections-wizards/tasks/update_connections_db_db2.yml
+++ b/roles/hcl/connections-wizards/tasks/update_connections_db_db2.yml
@@ -1,0 +1,38 @@
+---
+- name: Check if fixes in files are already deployed
+  shell: |
+    db2 connect to files > /dev/null
+    db2 -x select POSTSCHEMAVER from FILES.PRODUCT
+    db2 connect reset > /dev/null
+  become: true
+  become_user: "{{ __db2_user }}"
+  register: files_version
+
+- name: Check if fixes wikis are already deployed
+  shell: |
+    db2 connect to wikis > /dev/null
+    db2 -x select POSTSCHEMAVER from WIKIS.PRODUCT
+    db2 connect reset > /dev/null
+  become: true
+  become_user: "{{ __db2_user }}"
+  register: wikis_version
+
+- name: Download and unzip database update for 6.5CR1
+  unarchive:
+    src: "{{ __cnx_db_updates_url }}/{{ __cnx_db_update_file }}"
+    dest: "{{ __db_extraction_folder }}"
+    remote_src: yes
+  when: (files_version.stdout < 147.3) or (wikis_version.stdout < 147.3)
+  retries: 3
+
+- name: Update Files database
+  command: "db2 -td@ -vf {{ __db_extraction_folder }}/65cr1-database-updates/From-65/db2/65-65CR1-files-db2.sql"
+  become: true
+  become_user: "{{ __db2_user }}"
+  when: files_version.stdout < 147.3
+
+- name: Update Wikis database
+  command: "db2 -td@ -vf  {{ __db_extraction_folder }}/65cr1-database-updates/From-65/db2/65-65CR1-wikis-db2.sql"
+  become: true
+  become_user: "{{ __db2_user }}"
+  when: wikis_version.stdout < 147.3

--- a/roles/hcl/connections-wizards/vars/main.yml
+++ b/roles/hcl/connections-wizards/vars/main.yml
@@ -2,6 +2,10 @@
 db2_wizards_download_locaiton:  "{{ connections_wizards_download_location }}"
 db2_wizards_package_name:       "{{ connections_wizards_package_name }}"
 
+__cnx_fixes_version:            "{{ cnx_fixes_version }}"
+__cnx_db_updates_url:           "{{ cnx_db_updates_url }}"
+__cnx_db_update_file:          "{{ cnx_db_update_file | default('65cr1-database-updates.zip') }}"
+
 __db_enable_upgrades:           "{{ db_enable_upgrades | default(false) }}"
 __db_version:                   "{{ db_version | default('7.0') }}"
 __download_location:            "{{ connections_wizards_download_location | default('c7lb1.cnx.cwp.pnp-hcl.com:8001/Connections7') }}"
@@ -41,7 +45,7 @@ __ora_success_file:             "{{ __dbw_oracle_base }}/migration.success"
 __ora_ic360_success_file:       "{{ __dbw_oracle_base }}/ic360_migration.success"
 __ora_sharepoint_success_file:  "{{ __dbw_oracle_base }}/sharepoint_migration.success"
 __ora_docs_success_file:        "{{ __dbw_oracle_base }}/docs.migration.success"
-__oracle_migration_cmd:         "{{ __dbw_oracle_home }}/bin/sqlplus SYS/{{ __dbw_oracle_password }} as SYSDBA @" 
+__oracle_migration_cmd:         "{{ __dbw_oracle_home }}/bin/sqlplus SYS/{{ __dbw_oracle_password }} as SYSDBA @"
 
 __sql_data_folder:              "{{ sql_data_folder | default('/var/opt/mssql/data') }}"
 __sql_sa_password:              "{{ sql_sa_password | default('Pa55w0rd') }}"

--- a/roles/hcl/connections/post_install_config/tasks/setup_invite_config.yml
+++ b/roles/hcl/connections/post_install_config/tasks/setup_invite_config.yml
@@ -29,6 +29,8 @@
     path:                                   "{{ __selfreg_full_path }}"
     xpath:                                  "{{ __selfreg_invite_usertype_xpath }}"
     value:                                  "{{ invite_user_type | default('internal') }}"
+  when:
+    - __cnx_major_version == '7'
 
 
 - name:                                     Set Invite LDAP server href and ssl_href

--- a/roles/hcl/connections/post_install_config/vars/main.yml
+++ b/roles/hcl/connections/post_install_config/vars/main.yml
@@ -3,8 +3,9 @@ __profile_name:              "{{ profile_name | default('Dmgr01') }}"
 __was_cellname:              "{{ was_cellname | default('ConnectionsCell') }}"
 __app_profile_name:          "{{ app_profile_name | default('AppSrv01') }}"
 __was_install_location:      "{{ was_install_location  | default('/opt/IBM/WebSphere/AppServer') }}"
-__bin_dir:                  "{{ __was_install_location }}/profiles/{{ __profile_name }}/bin"
+__bin_dir:                   "{{ __was_install_location }}/profiles/{{ __profile_name }}/bin"
 
+__cnx_major_version:         "{{ cnx_major_version | default('7') }}"
 
 # LDAP defaults
 

--- a/roles/hcl/connections/tasks/download_extract_connections.yml
+++ b/roles/hcl/connections/tasks/download_extract_connections.yml
@@ -62,6 +62,13 @@
 - name:              "Get the installation ID"
   shell:             cat "{{ __tmp_dir }}/cnx/HCL_Connections_Install/HCLConnections/repository.xml" | grep "offering id" | grep version | awk {'print $3'} | cut -d'=' -f2 | cut -d '>' -f1 | tail -c +2 | head -c -2
   register:          cnx_upgrade_version
+  when:              (cnx_fixes_version is not defined)
+
+- name:              "Get the installation ID from CR1"
+  # offering id appears three times in the repository file, so limiting to last occurrence
+  shell:             cat "{{ __tmp_dir }}/cnx-cr/updates/repository.xml" | grep "offering id" | tail -n1 | awk {'print $3'} | cut -d'=' -f2 | cut -d '>' -f1 | tail -c +2 | head -c -2
+  register:          cnx_upgrade_version
+  when:              (cnx_fixes_version is defined)
 
 - debug: var=cnx_upgrade_version.stdout
   run_once: true


### PR DESCRIPTION
Hi,
I wrote down all adjustments I did to deploy the very last Connections 6.5CR1, here is the PR.
One thing, the documentation/howtos/connections_upgrade.md need a complete rework, as it points to old inventory files (from the time where variables are also defined there) and variables are not written down, all are only linked with line numbers, no idea which ones are really meant.
Additionally I would recommend to change all 6.5.0.1 to 6.5.0.0_CR1 or 6.5CR1 as there never was a version 6.5.0.1
Regards
Christoph

Some points are discusssed already [here](https://github.com/HCL-TECH-SOFTWARE/connections-automation/issues/158#issue-1041308006) and [here](https://github.com/HCL-TECH-SOFTWARE/connections-automation/issues/153#issue-1039228334)