### PR TITLE
Replace hardcoded NFS Shares with variables

### DIFF
--- a/roles/hcl/connections/vars/main.yml
+++ b/roles/hcl/connections/vars/main.yml
@@ -36,13 +36,13 @@ __firstNfsNode:              "{{ hostvars[groups['nfs_servers'][0]]['ansible_def
 __nfsMasterAddress:          "{{ nfsMasterAddress | default( __firstNfsNode ) }}"
 
 __cnx_shared_area:           "{{ cnx_shared_area  | default('/opt/IBM/SharedArea') }}"
-__cnx_shared_area_nfs:       "/nfs/data/shared"
+__cnx_shared_area_nfs:       "{{ cnx_data_remote_path | default('/nfs/data/shared') }}"
 __cnx_shared_area_files_dest: "{{ __nfsMasterAddress }}:{{ __cnx_shared_area_nfs }}"
 
 __cnx_webserver:             "{{ cnx_webserver | default( hostvars[groups['ihs_servers'][0]]['inventory_hostname_short'] ) }}"
 
 __cnx_message_store:         "{{ cnx_message_store  | default('/opt/HCL/MessageStore') }}"
-__cnx_message_store_nfs:     "/nfs/data/messageStores"
+__cnx_message_store_nfs:     "{{ cnx_message_store_remote_path | default('/nfs/data/messageStores') }}"
 __cnx_messagestore_files_dest: "{{ __nfsMasterAddress }}:{{ __cnx_message_store_nfs }}"
 
 __this_version:              "{{ cnx_version | default('6.5.0.0_20191121_2323') }}"

--- a/roles/third_party/nfs-install/vars/main.yml
+++ b/roles/third_party/nfs-install/vars/main.yml
@@ -6,9 +6,9 @@ __nfs_docs_setup:                    "{{ nfs_docs_setup | default('true') }}"
 
 __nfs_export_netmask:                "{{ nfs_export_netmask | default( hostvars[groups['nfs_servers'][0]]['ansible_default_ipv4']['netmask'] ) }}"
 
-__cnx_data_shared:                   "{{ cnx_shared_area | default('/nfs/data/shared') }}"
+__cnx_data_shared:                   "{{ cnx_shared_remote_path | default('/nfs/data/shared') }}"
 
-__cnx_message_stores:                "{{ cnx_message_store | default('/nfs/data/messageStores') }}"
+__cnx_message_stores:                "{{ cnx_message_store_remote_path | default('/nfs/data/messageStores') }}"
 
 __docs_data_shared:                  "{{ docs_data_shared | default('/nfs/docs_data') }}"
 __viewer_data_shared:                "{{ viewer_data_shared | default('/nfs/viewer_data') }}"


### PR DESCRIPTION
During the setup I had issues when I wanted to adjust the path names on the NFS Server. I found hardcoded path names and the wrong variables used on the NFS Server.
On the NFS server the content of _remote_path needs to be used, so it creates the matching folders for the nfs mounts or message stores and shared area.