### PR TITLE
Fix cnx_upgrade_version not properly defined for 6.5CR1

### DIFF
--- a/roles/hcl/connections/tasks/download_extract_connections.yml
+++ b/roles/hcl/connections/tasks/download_extract_connections.yml
@@ -72,7 +72,7 @@
 
 - name:              Set cnx_upgrade_version
   set_fact:
-    cnx_upgrade_version:  "{{ cnx_upgrade_version_base if (cnx_upgrade_version_base is defined) else cnx_upgrade_version_cr }}"
+    cnx_upgrade_version:  "{{ cnx_upgrade_version_base if (cnx_upgrade_version_base is changed) else cnx_upgrade_version_cr }}"
 
 - debug: var=cnx_upgrade_version.stdout
   run_once: true


### PR DESCRIPTION
`cnx_upgrade_version_base` is always defined per Ansible behavior as designed.  Update condition to check for `is changed`.