### PR TITLE
RHEL8 Docs - set python2 if only needed

### DIFF
--- a/roles/hcl/docs/tasks/cleanup_env.yml
+++ b/roles/hcl/docs/tasks/cleanup_env.yml
@@ -1,0 +1,28 @@
+---
+- name:                    Cleanup Install Binaries directory
+  file:
+    state:                 absent
+    path:                  "{{ __extraction_folder }}"
+
+- name:                    Verify if python default was changed on RHEL 8
+  stat:
+    path:                  "{{ __hcl_program_folder }}/python2_alternatives_set.success"
+  register:                python2_default_was_set
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == "8"
+
+- name:                    Unset python2 as default on RHEL 8
+  command:                 alternatives --set python /usr/bin/python3
+  become:                  true
+  register:                python2_alternatives_unset
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == "8"
+    - python2_default_was_set.stat.exists
+
+- name:                    Remove python2_alternatives_set.success file on RHEL 8
+  file:
+    path:                  "{{ __hcl_program_folder }}/python2_alternatives_set.success"
+    state:                 absent
+  when:                    python2_alternatives_unset is changed

--- a/roles/hcl/docs/tasks/download_docs.yml
+++ b/roles/hcl/docs/tasks/download_docs.yml
@@ -83,9 +83,28 @@
     - ansible_distribution_major_version == "8"
     - python_installed.failed
 
-- name:                  Set python2 as default for RHEL 8
-  command:               alternatives --set python /usr/bin/python2
-  become:                true
+- name:                  Get default python version on RHEL 8
+  command:               python --version
+  register:              python_default_version
+  ignore_errors:         true
   when:
     - ansible_os_family == "RedHat"
     - ansible_distribution_major_version == "8"
+
+- name:                  Print current default python version on RHEL 8
+  debug:                 var=python_default_version
+
+- name:                  Set python2 as default for RHEL 8
+  command:               alternatives --set python /usr/bin/python2
+  become:                true
+  register:              python2_alternatives_set
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == "8"
+    - (python_default_version is defined) and (python_default_version is not search("Python 2"))
+
+- name:                  Create python2_alternatives_set.success file
+  file:
+    path:                "{{ __hcl_program_folder }}/python2_alternatives_set.success"
+    state:               touch
+  when:                  python2_alternatives_set is changed

--- a/roles/hcl/docs/tasks/main.yml
+++ b/roles/hcl/docs/tasks/main.yml
@@ -75,8 +75,7 @@
   include_tasks:           propagate_plugin.yml
   when:                    inventory_hostname in groups["ihs_servers"]
 
-
-- name:                    Cleanup Install Binaries directory
-  file:
-    state:                 absent
-    path:                  "{{ __extraction_folder }}"
+- name:                    Cleanup environments
+  include_tasks:           cleanup_env.yml
+  when:
+   - (inventory_hostname in groups["docs_servers"] or inventory_hostname in groups["conversion_servers"] or inventory_hostname in groups["viewer_servers"][0] or inventory_hostname in groups["proxy_servers"][0]) or inventory_hostname in groups["cnx_was_servers"][0]


### PR DESCRIPTION
Docs install needs python2 to run, this PR sets it to default if not currently set.
