### PR TITLE
Upgrade Haproxy default version to 2.5.1

### DIFF
--- a/roles/third_party/haproxy-install/vars/main.yml
+++ b/roles/third_party/haproxy-install/vars/main.yml
@@ -1,6 +1,6 @@
 ---
-__haproxy_version:                       "{{ haproxy_version | default('2.4.0') }}"
-__haproxy_major_version:                 "{{ haproxy_major_version | default('2.4') }}"
+__haproxy_version:                       "{{ haproxy_version | default('2.5.1') }}"
+__haproxy_major_version:                 "{{ haproxy_major_version | default('2.5') }}"
 __haproxy_url:                           "http://www.haproxy.org/download/{{ __haproxy_major_version }}/src/haproxy-{{ __haproxy_version }}.tar.gz"
 __haproxy_download_dir:                  "/tmp/haproxy-{{ __haproxy_version }}"
 


### PR DESCRIPTION
Change Haproxy default version 2.5.1