### PR TITLE
Add ifix installation to complete playbooks

### DIFF
--- a/playbooks/setup-connections-complete.yml
+++ b/playbooks/setup-connections-complete.yml
@@ -21,3 +21,4 @@
 
 - name:                  Update HCL Connections
   import_playbook:       hcl/setup-connections-ifix.yml
+  when:                  ifix_apar is defined

--- a/playbooks/setup-connections-complete.yml
+++ b/playbooks/setup-connections-complete.yml
@@ -18,3 +18,6 @@
 
 - name:                  Setup HCL Connections
   import_playbook:       hcl/setup-connections-only.yml
+
+- name:                  Update HCL Connections
+  import_playbook:       hcl/setup-connections-ifix.yml

--- a/playbooks/setup-trial-environment.yml
+++ b/playbooks/setup-trial-environment.yml
@@ -31,5 +31,8 @@
 - name:                  Setup Connections
   import_playbook:       hcl/setup-connections.yml
 
+- name:                  Update HCL Connections
+  import_playbook:       hcl/setup-connections-ifix.yml
+
 - name:                  Setup Component Pack
   import_playbook:       hcl/setup-component-pack.yml


### PR DESCRIPTION
Complete playbooks did not update to the configured CFix, the included statement for the ifix playbook is missing. With this PR the playbooks update Connections to the configured CFix version.