### PR TITLE
Add comment to update and uncomment the cfix properties

### DIFF
--- a/environments/examples/cnx7/db2/group_vars/all.yml
+++ b/environments/examples/cnx7/db2/group_vars/all.yml
@@ -77,9 +77,10 @@ cnx_enable_full_icec:                            true
 
 enable_prometheus_jmx_exporter:                  True
 
-ifix_apar:                                       CFix.70.2110
-cnx_ifix_installer:                              "updateInstaller_2104.zip"
-ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
+# uncomment these lines, set to the latest cFix to include it as part of the initial install 
+#ifix_apar:                                       CFix.70.2110
+#cnx_ifix_installer:                              "updateInstaller_2104.zip"
+#ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
 
 setup_docker_registry:                           true
 component_pack_package_name:                     hybridcloud_latest.zip

--- a/environments/examples/cnx7/flexnet_db2/group_vars/all.yml
+++ b/environments/examples/cnx7/flexnet_db2/group_vars/all.yml
@@ -83,9 +83,10 @@ cnx_enable_invite:                               true
 
 enable_prometheus_jmx_exporter:                  True
 
-ifix_apar:                                       LO100079
-cnx_ifix_installer:                              "updateInstaller_2102.zip"
-ifix_file:                                       HCL_Connections_70_Update.jar
+# uncomment these lines, set to the latest cFix to include it as part of the initial install 
+# ifix_apar:                                       LO100079
+# cnx_ifix_installer:                              "updateInstaller_2102.zip"
+# ifix_file:                                       HCL_Connections_70_Update.jar
 
 setup_docker_registry:                           true
 component_pack_package_name:                     hybridcloud_latest.zip

--- a/environments/examples/cnx7/mssql/group_vars/all.yml
+++ b/environments/examples/cnx7/mssql/group_vars/all.yml
@@ -78,9 +78,10 @@ cnx_enable_full_icec:                            true
 
 enable_prometheus_jmx_exporter:                  True
 
-ifix_apar:                                       CFix.70.2110
-cnx_ifix_installer:                              "updateInstaller_2104.zip"
-ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
+# uncomment these lines, set to the latest cFix to include it as part of the initial install
+# ifix_apar:                                       CFix.70.2110
+# cnx_ifix_installer:                              "updateInstaller_2104.zip"
+# ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
 
 setup_docker_registry:                           true
 component_pack_package_name:                     hybridcloud_latest.zip

--- a/environments/examples/cnx7/oracle/group_vars/all.yml
+++ b/environments/examples/cnx7/oracle/group_vars/all.yml
@@ -93,9 +93,10 @@ cnx_enable_full_icec:                            true
 
 enable_prometheus_jmx_exporter:                  True
 
-ifix_apar:                                       CFix.70.2110
-cnx_ifix_installer:                              "updateInstaller_2104.zip"
-ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
+# uncomment these lines, set to the latest cFix to include it as part of the initial install
+# ifix_apar:                                       CFix.70.2110
+# cnx_ifix_installer:                              "updateInstaller_2104.zip"
+# ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
 
 setup_docker_registry:                           true
 component_pack_package_name:                     hybridcloud_latest.zip

--- a/environments/examples/cnx7/quick_start/group_vars/all.yml
+++ b/environments/examples/cnx7/quick_start/group_vars/all.yml
@@ -71,10 +71,10 @@ cnx_enable_invite:                               true
 
 enable_prometheus_jmx_exporter:                  True
 
-# update these for the latest fix and updateInstaller
-ifix_apar:                                       CFix.70.2110
-cnx_ifix_installer:                              "updateInstaller_2104.zip"
-ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
+# uncomment these lines, set to the latest cFix to include it as part of the initial install
+# ifix_apar:                                       CFix.70.2110
+# cnx_ifix_installer:                              "updateInstaller_2104.zip"
+# ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
 
 setup_docker_registry:                           true
 component_pack_package_name:                     component_pack_latest.zip

--- a/environments/examples/existing_database/db2/group_vars/all.yml
+++ b/environments/examples/existing_database/db2/group_vars/all.yml
@@ -76,9 +76,10 @@ cnx_enable_full_icec:                            true
 
 enable_prometheus_jmx_exporter:                  True
 
-ifix_apar:                                       CFix.70.2110
-cnx_ifix_installer:                              "updateInstaller_2104.zip"
-ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
+# uncomment these lines, set to the latest cFix to include it as part of the initial install
+# ifix_apar:                                       CFix.70.2110
+# cnx_ifix_installer:                              "updateInstaller_2104.zip"
+# ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
 
 setup_docker_registry:                           true
 component_pack_package_name:                     hybridcloud_latest.zip

--- a/environments/examples/existing_database/mssql/group_vars/all.yml
+++ b/environments/examples/existing_database/mssql/group_vars/all.yml
@@ -74,9 +74,10 @@ cnx_enable_full_icec:                            true
 
 enable_prometheus_jmx_exporter:                  True
 
-ifix_apar:                                       CFix.70.2110
-cnx_ifix_installer:                              "updateInstaller_2104.zip"
-ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
+# uncomment these lines, set to the latest cFix to include it as part of the initial install
+# ifix_apar:                                       CFix.70.2110
+# cnx_ifix_installer:                              "updateInstaller_2104.zip"
+# ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
 
 setup_docker_registry:                           true
 component_pack_package_name:                     hybridcloud_latest.zip

--- a/environments/examples/existing_database/oracle/group_vars/all.yml
+++ b/environments/examples/existing_database/oracle/group_vars/all.yml
@@ -92,9 +92,10 @@ cnx_enable_full_icec:                            true
 
 enable_prometheus_jmx_exporter:                  True
 
-ifix_apar:                                       CFix.70.2110
-cnx_ifix_installer:                              "updateInstaller_2104.zip"
-ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
+# uncomment these lines, set to the latest cFix to include it as part of the initial install 
+# ifix_apar:                                       CFix.70.2110
+# cnx_ifix_installer:                              "updateInstaller_2104.zip"
+# ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
 
 setup_docker_registry:                           true
 component_pack_package_name:                     hybridcloud_latest.zip

--- a/environments/examples/vagrant/group_vars/all.yml
+++ b/environments/examples/vagrant/group_vars/all.yml
@@ -71,9 +71,10 @@ cnx_enable_full_icec:                            true
 
 enable_prometheus_jmx_exporter:                  True
 
-ifix_apar:                                       CFix.70.2110
-cnx_ifix_installer:                              "updateInstaller_2104.zip"
-ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
+# uncomment these lines, set to the latest cFix to include it as part of the initial install
+# ifix_apar:                                       CFix.70.2110
+# cnx_ifix_installer:                              "updateInstaller_2104.zip"
+# ifix_file:                                       CFix.70.2110-IC7.0.0.0-Common-Fix.jar
 
 setup_docker_registry:                           true
 component_pack_package_name:                     component_pack_latest.zip


### PR DESCRIPTION
New cFix is released periodically so adding a comment to inventories to prompt for update and uncomment to avoid installing old cFix by mistake.