### PR TITLE
Store registry ca with the hostname of the registry server

### DIFF
--- a/roles/third_party/docker-install/vars/main.yml
+++ b/roles/third_party/docker-install/vars/main.yml
@@ -14,9 +14,9 @@ __registry_user:                "{{ registry_user | default('admin') }}"
 __registry_password:            "{{ registry_password | default('password') }}"
 
 __certs_folder:                 "/etc/docker/certs"
-__registry_cert:                "/etc/docker/certs.d/{{ inventory_hostname }}:5000"
+__registry_cert:                "/etc/docker/certs.d/{{ groups['docker_registry'][0] }}:5000"
 
 __overlay2_enabled:             "{{ overlay2_enabled | default(true) }}"
 
 __docker_cnf_template:          "cert.cnf.j2"
-__docker_cnf_location:          "{{ __certs_folder }}/{{ groups['docker_registry'][0] }}.cnf"
+__docker_cnf_location:          "{{ __certs_folder }}/{{ inventory_hostname }}.cnf"

--- a/roles/third_party/docker-install/vars/main.yml
+++ b/roles/third_party/docker-install/vars/main.yml
@@ -19,4 +19,4 @@ __registry_cert:                "/etc/docker/certs.d/{{ inventory_hostname }}:50
 __overlay2_enabled:             "{{ overlay2_enabled | default(true) }}"
 
 __docker_cnf_template:          "cert.cnf.j2"
-__docker_cnf_location:          "{{ __certs_folder }}/{{ inventory_hostname }}.cnf"
+__docker_cnf_location:          "{{ __certs_folder }}/{{ groups['docker_registry'][0] }}.cnf"


### PR DESCRIPTION
In a multinode Kubernetes cluster, the registry server is the first server in group `docker_registry`. The `ca.cert` for accessing the registry is created in a folder with `{{ inventory_hostname }`, but this needs to be the registry_server or it generates an error: 

```
x509: certficate signed by unknown authority
```

 