### PR TITLE
Comment out teams-tab/api, because it is already included

### DIFF
--- a/roles/third_party/ibm/ihs/ibm-http-httpdconf/templates/httpd.conf.j2
+++ b/roles/third_party/ibm/ihs/ibm-http-httpdconf/templates/httpd.conf.j2
@@ -950,9 +950,14 @@ ProxyPassReverse "/teams-share-service" "http://{{ __load_balancer_fqdn }}:32080
 ProxyPass "/teams-share-ui" "http://{{ __load_balancer_fqdn }}:32080/teams-share-ui"
 ProxyPassReverse "/teams-share-ui" "http://{{ __load_balancer_fqdn }}:32080/teams-share-ui"
 
+# teams-tab-ui
+ProxyPass "/teams-tab" "http://{{ __load_balancer_fqdn }}:32080/teams-tab"
+ProxyPassReverse "/teams-tab" "http://{{ __load_balancer_fqdn }}:32080/teams-tab"
+
+# commented out, already included in rule above
 # teams-tab/api
-ProxyPass "/teams-tab/api" "http://{{ __load_balancer_fqdn }}:32080/teams-tab/api"
-ProxyPassReverse "/teams-tab/api" "http://{{ __load_balancer_fqdn }}:32080/teams-tab/api"
+# ProxyPass "/teams-tab/api" "http://{{ __load_balancer_fqdn }}:32080/teams-tab/api"
+# ProxyPassReverse "/teams-tab/api" "http://{{ __load_balancer_fqdn }}:32080/teams-tab/api"
 
 # proxy rules for admin-portal
 ProxyPass "/cnxadmin" "http://{{ __load_balancer_fqdn }}:32080/cnxadmin"
@@ -1022,9 +1027,10 @@ ProxyPassReverse "/api-boards" "http://{{ __load_balancer_fqdn }}:32080/api-boar
 ProxyPass "/teams-tab" "http://{{ __load_balancer_fqdn }}:32080/teams-tab"
 ProxyPassReverse "/teams-tab" "http://{{ __load_balancer_fqdn }}:32080/teams-tab"
 
+# commented out, already included in rule above
 # teams-tab/api
-ProxyPass "/teams-tab/api" "http://{{ __load_balancer_fqdn }}:32080/teams-tab/api"
-ProxyPassReverse "/teams-tab/api" "http://{{ __load_balancer_fqdn }}:32080/teams-tab/api"
+# ProxyPass "/teams-tab/api" "http://{{ __load_balancer_fqdn }}:32080/teams-tab/api"
+# ProxyPassReverse "/teams-tab/api" "http://{{ __load_balancer_fqdn }}:32080/teams-tab/api"
 
 # teams-share-service
 ProxyPass "/teams-share-service" "http://{{ __load_balancer_fqdn }}:32080/teams-share-service"


### PR DESCRIPTION
Restarting or Starting HTTP Server generates warning/error on console:

/opt/IBM/HTTPServer/bin/apachectl -k stop
[Tue Oct 18 09:02:07 2022] [warn] worker http://cnx7-ora-cp.stoeps.home:32080/teams-tab already used by another worker

Reason are duplicate proxypass definitions for /teams-tab and /teams-tab/api, the api rule is already included in the first rule, so no need to proxypass both urls.

I commented out the additional rule (/teams-tab was missing in the ssl section, but still in non-ssl / generic) 

If the /teams-tab is no longer needed, then please remove from ssl and general part of the config. If it is still needed merge this PR please.