### PR TITLE
Replace ansible_distribution=Redhat with ansible_os_family == Redhat

### DIFF
--- a/roles/third_party/containerd-install/tasks/install_containerd.yml
+++ b/roles/third_party/containerd-install/tasks/install_containerd.yml
@@ -87,7 +87,7 @@
     regexp:                 'systemd_cgroup.=.*$'
     replace:                'systemd_cgroup = true'
   when:
-   - ansible_distribution == "RedHat"
+   - ansible_os_family == "RedHat"
    - ansible_distribution_major_version == "7"
 
 - name:                     Restart containerd

--- a/roles/third_party/docker-install/tasks/install_docker_centos_redhat.yml
+++ b/roles/third_party/docker-install/tasks/install_docker_centos_redhat.yml
@@ -27,7 +27,7 @@
     regexp:                 '^baseurl.*$'
     replace:                'baseurl=https://download.docker.com/linux/centos/8/x86_64/stable'
   when:
-    - ansible_distribution == "RedHat"
+    - ansible_os_family == "RedHat"
     - ansible_distribution_major_version == "8"
 
 - name:                     Enable Docker stable repo

--- a/roles/third_party/ibm/tdi-install/tasks/setup_os.yml
+++ b/roles/third_party/ibm/tdi-install/tasks/setup_os.yml
@@ -11,5 +11,5 @@
     name:            libnsl
     state:           present
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS"
+    - ansible_os_family == "RedHat" or ansible_distribution == "CentOS"
     - ansible_distribution_major_version == "8"

--- a/roles/third_party/ldap-install/tasks/install_openldap.yml
+++ b/roles/third_party/ldap-install/tasks/install_openldap.yml
@@ -10,13 +10,13 @@
     name:                   ['openldap', 'openldap-clients', 'openldap-servers', 'openldap-devel']
     state:                   present
   when:
-    - ansible_distribution == "RedHat"
+    - ansible_os_family == "RedHat"
     - ansible_distribution_major_version != "8"
 
 - name:                     Install OpenLDAP and dependencies on RHEL8
   include_tasks:            install_symas_openldap.yml
   when:
-    - ansible_distribution == "RedHat"
+    - ansible_os_family == "RedHat"
     - ansible_distribution_major_version == "8"
 
 - name:                     Start slapd service
@@ -56,7 +56,7 @@
     dest:                   "{{ __db_ldif_location }}"
   when:
     - not ldap_database_already_created.stat.exists
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS"
+    - ansible_os_family == "RedHat" or ansible_distribution == "CentOS"
     - ansible_distribution_major_version == "8"
 
 - name:                     Create LDAP database

--- a/roles/third_party/ldap-install/tasks/install_symas_openldap.yml
+++ b/roles/third_party/ldap-install/tasks/install_symas_openldap.yml
@@ -28,11 +28,6 @@
     url:                    https://repo.symas.com/configs/SOFL/rhel8/sofl.repo
     dest:                   /etc/yum.repos.d/sofl.repo
 
-- name:                     Upgrade all packages
-  yum:
-    name:                   '*'
-    state:                  latest
-
 - name:                     Install symas-openldap-clients for Linux on RHEL8
   package:
     name:                   symas-openldap-clients

--- a/roles/third_party/ldap-install/tasks/main.yml
+++ b/roles/third_party/ldap-install/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name:                      Install OpenLDAP
-  include_tasks:             install_openldap.yml
+  include_tasks:             install_symas_openldap.yml
 
 - name:                      Configure OpenLDAP
   include_tasks:             configure_openldap.yml

--- a/roles/third_party/nginx-install/tasks/setup_os.yml
+++ b/roles/third_party/nginx-install/tasks/setup_os.yml
@@ -16,7 +16,7 @@
     dist:                   "rhel"
     version:                "{{ ansible_distribution_major_version }}"
   when:
-   - ansible_distribution == "RedHat"
+   - ansible_os_family == "RedHat"
 
 - name:                     Install prerequisits for semanage
   package:
@@ -26,7 +26,7 @@
     - libselinux-python
     - libsemanage-python
   when:
-   - ansible_distribution == "RedHat"
+   - ansible_os_family == "RedHat"
    - ansible_distribution_major_version == "7"
 
 

--- a/roles/third_party/oracle-install/tasks/install_oracle.yml
+++ b/roles/third_party/oracle-install/tasks/install_oracle.yml
@@ -22,7 +22,7 @@
   when:
     - oracle_already_running.rc != 0
     - not oracle_prereqs_already_ran.stat.exists
-    - ansible_distribution == "RedHat"
+    - ansible_os_family == "RedHat"
     - ansible_distribution_major_version == "8"
   ignore_errors:         yes
 


### PR DESCRIPTION
To test the installation with a binary compatible replacement like Rocky Linux, Alma Linux, Oracle Linux or Amazon Linux, the usage of ansible_distribution is not working.
Even when the replacements are not officially supported, it helps us to test on different platforms and does not interfere with a real Red Hat deployment.
