### PR TITLE
Replace first master with component_pack_master group to fix failed copy

### DIFF
--- a/roles/hcl/component-pack-harbor/tasks/enable_es_metrics.yml
+++ b/roles/hcl/component-pack-harbor/tasks/enable_es_metrics.yml
@@ -230,7 +230,7 @@
 
 - name:                      Copy the archive from controller
   copy:
-    src:                     "/tmp/{{ groups['k8s_masters'][0] }}/{{ __es_certs_dir }}/es_certificates_signed.zip"
+    src:                     "/tmp/{{ groups['component_pack_master'][0] }}/{{ __es_certs_dir }}/es_certificates_signed.zip"
     dest:                    "/tmp"
   delegate_to:               "{{ item }}"
   with_items:                "{{ groups['was_servers'] }}"


### PR DESCRIPTION
Fixes issue https://github.com/HCL-TECH-SOFTWARE/connections-automation/issues/281

The role fails without this PR, when the component_pack_master and k8s_master[0] are different.