### PR TITLE
Add variables to TDIsol configuration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Gyanendu Prakash, HCL
 Christoph Stoettner, Vegard IT
 Nitin Jagjivan, HCL
 Andrew Welch, ISW - Huddo Boards
+Martin Vogel,

--- a/documentation/VARIABLES.md
+++ b/documentation/VARIABLES.md
@@ -39,6 +39,7 @@ See [Sample Inventories](https://github.com/HCL-TECH-SOFTWARE/connections-automa
 Name | Default | Description
 ---- | --------| -------------
 setup_fake_ldap_users | true | true creates dummy ldap users
+ldap_bind_user | cn=Admin,dc=cnx,dc=pnp-hcl,dc=com | Ldap bind user
 ldap_bind_pass | password | Password for simple authentication
 ldap_realm | dc=cnx,dc=pnp-hcl,dc=com | This directive specifies the DN suffix of queries that will be passed to this backend database
 ldap_admin_user | Admin | Ldap admin user
@@ -48,6 +49,11 @@ ldap_user_password | password | Password for the ldap users
 ldap_user_admin_password | password | Ldap user admin password
 ldap_user_mail_domain | connections.example.com | Ldap user email domain
 ldap_setup_internal | false | true sets up internal users
+ldap_repo | LDAP_PRODUCTION1 | Name of the LDAP repo in WebSphere configuration
+ldap_login_properties | mail;uid | Login properties in WebSphere configuration
+ldap_search_filter | (objectclass=inetOrgPerson) | Ldap search filter
+ldap_map_guid | entryUUID | mapping for guid property
+ldap_map_uid | uid | mapping for uid property
 
 ### Database Variables
 Name | Default | Description

--- a/roles/third_party/ibm/tdi-install/templates/map_dbrepos_from_source.properties.j2
+++ b/roles/third_party/ibm/tdi-install/templates/map_dbrepos_from_source.properties.j2
@@ -53,7 +53,7 @@ floor=null
 givenName=givenName
 givenNames=givenName
 groupwareEmail=null
-guid=entryUUID
+guid={{ __ldap_map_guid }}
 ipTelephoneNumber=null
 #if there is no ldap attribute that denotes a person is a manager,
 #run the mark_manager script after population
@@ -86,7 +86,7 @@ telephoneNumber=telephoneNumber
 tenantKey=null
 timezone=null
 title=null
-uid=uid
+uid={{ __ldap_map_uid }}
 workLocationCode=l
 
 mode=employeeType

--- a/roles/third_party/ibm/tdi-install/templates/profiles_tdi.properties.j2
+++ b/roles/third_party/ibm/tdi-install/templates/profiles_tdi.properties.j2
@@ -18,7 +18,7 @@
 
 source_ldap_url=ldap://{{ __ldap_server }}:389
 source_ldap_search_base={{ __ldap_realm }}
-source_ldap_search_filter=(objectclass=inetOrgPerson)
+source_ldap_search_filter={{ __ldap_search_filter }}
 source_ldap_user_login={{ __ldap_bind_user }}
 {protect}-source_ldap_user_password={{ __ldap_bind_pass }}
 

--- a/roles/third_party/ibm/tdi-install/vars/main.yml
+++ b/roles/third_party/ibm/tdi-install/vars/main.yml
@@ -66,6 +66,9 @@ __ldap_server_default:          "{{ hostvars[groups['ldap_servers'][0]]['invento
 __ldap_server:                  "{{ ldap_server | default( __ldap_server_default ) }}"
 __ldap_bind_user:               "{{ ldap_bind_user | default('cn=Admin,dc=cnx,dc=pnp-hcl,dc=com') }}"
 __ldap_bind_pass:               "{{ ldap_bind_pass | default('password') }}"
+__ldap_search_filter:           "{{ ldap_search_filter | default('(objectclass=inetOrgPerson)') }}"
+__ldap_map_guid:                "{{ ldap_map_guid | default('entryUUID') }}"
+__ldap_map_uid:                 "{{ ldap_map_uid | default('uid') }}"
 
 __db_hostname_default:          "{{ hostvars[groups['db_servers'][0]]['inventory_hostname'] }}"
 __db_hostname:                  "{{ db_hostname | default( __db_hostname_default ) }}"


### PR DESCRIPTION
Fixes #289

I added the variables for search filter, guid and uid in vars and template files.

I decided to add _map extension for variables used in map_dbrepos_from_source.properties template like `ldap_map_guid".

With this PR it will be possible to set the ldap configuration for different ldap server.