### PR TITLE
Fix - TDI configuration java.policy file

### DIFF
--- a/roles/third_party/ibm/tdi-install/tasks/upgrade-tdi-jre.yml
+++ b/roles/third_party/ibm/tdi-install/tasks/upgrade-tdi-jre.yml
@@ -75,7 +75,7 @@
     marker:                 "// {mark} Grant all permissions to all files in the SDI install dir"
     insertafter:            "// Standard extensions get all permissions by default"
     block:                  |
-                            grant codeBase "file:"{{ __tdi_user_install_dir }}"/*" {
+                            grant codeBase "file:{{ __tdi_user_install_dir }}/*" {
                                     permission java.security.AllPermission;
                             };
   when:


### PR DESCRIPTION
I removed quotation marks in line `grant codeBase "file:"{{ __tdi_user_install_dir }}"/*" { `

**Background info:**
In a new deployment the collect_dns task can't finished successfuly with the following error message:

> ERROR [com.ibm.di.TDIProperties] - CTGDKE039E Error occurred when creating IBM Security Directory Integrator Property store. Property store: System-P
> roperties Exception: java.sql.SQLNonTransientConnectionException: java.net.ConnectException : Error connecting to server localhost on port 1527 with message Connection refus
> ed (Connection refused).

In a cross-check the following errors are seen when running `./netstore start`

logs/netstore.err
> java.security.policy: error parsing file:/opt/IBM/TDI/V7.20/jvm/jre/lib/security/java.policy:
>         line 15: expected codeBase or SignedBy or Principal


logs/netstore.out

> Thu Jul 13 15:01:01 CEST 2023 : Security manager installed using the Basic server security policy.
> Thu Jul 13 15:01:02 CEST 2023 : Access denied ("java.net.SocketPermission" "localhost:1527" "listen,resolve")
> java.security.AccessControlException: Access denied ("java.net.SocketPermission" "localhost:1527" "listen,resolve")
>         at java.security.AccessController.throwACE(AccessController.java:176)
>         at java.security.AccessController.checkPermissionHelper(AccessController.java:238)
>         at java.security.AccessController.checkPermission(AccessController.java:385)
>         at java.lang.SecurityManager.checkPermission(SecurityManager.java:562)
>         at java.lang.SecurityManager.checkListen(SecurityManager.java:1144)
>         at java.net.ServerSocket.bind(ServerSocket.java:443)
>         at java.net.ServerSocket.<init>(ServerSocket.java:258)
>         at javax.net.DefaultServerSocketFactory.createServerSocket(ServerSocketFactory.java:2)
>         at org.apache.derby.impl.drda.NetworkServerControlImpl.createServerSocket(Unknown Source)
>         at org.apache.derby.impl.drda.NetworkServerControlImpl.access$000(Unknown Source)
>         at org.apache.derby.impl.drda.NetworkServerControlImpl$1.run(Unknown Source)
>         at java.security.AccessController.doPrivileged(AccessController.java:734)
>         at org.apache.derby.impl.drda.NetworkServerControlImpl.blockingStart(Unknown Source)
>         at org.apache.derby.impl.drda.NetworkServerControlImpl.executeWork(Unknown Source)
>         at org.apache.derby.drda.NetworkServerControl.main(Unknown Source)
> 


The reason for this error was this configuration block in the java.policy file.

```
grant codeBase "file:"/opt/IBM/TDI/V7.20"/*" {
        permission java.security.AllPermission;
};
```
