### PR TITLE
Fix - all variables enclosed in quotes

### DIFF
--- a/roles/third_party/ibm/wasnd/was-dmgr-config-ldap/templates/was_config_ldap.py.j2
+++ b/roles/third_party/ibm/wasnd/was-dmgr-config-ldap/templates/was_config_ldap.py.j2
@@ -1,10 +1,10 @@
 #Create LDAP Repository
-AdminTask.createIdMgrLDAPRepository('[-default true -id {{ __ldap_repo }} -adapterClassName com.ibm.ws.wim.adapter.ldap.LdapAdapter -ldapServerType CUSTOM -sslConfiguration -certificateMapMode exactdn -supportChangeLog none -certificateFilter -loginProperties {{ __ldap_login_properties }}]')
+AdminTask.createIdMgrLDAPRepository('[-default true -id "{{ __ldap_repo }}" -adapterClassName com.ibm.ws.wim.adapter.ldap.LdapAdapter -ldapServerType CUSTOM -sslConfiguration -certificateMapMode exactdn -supportChangeLog none -certificateFilter -loginProperties "{{ __ldap_login_properties }}"]')
 #Add LDAP Server
-AdminTask.addIdMgrLDAPServer('[-id {{ __ldap_repo }} -host {{ __ldap_server }} -bindDN {{ __ldap_bind_user }} -bindPassword {{ __ldap_bind_pass }} -referal ignore -sslEnabled false -ldapServerType CUSTOM -sslConfiguration -certificateMapMode exactdn -certificateFilter -authentication simple -port 389]')
+AdminTask.addIdMgrLDAPServer('[-id "{{ __ldap_repo }}" -host "{{ __ldap_server }}" -bindDN "{{ __ldap_bind_user }}" -bindPassword "{{ __ldap_bind_pass }}" -referal ignore -sslEnabled false -ldapServerType CUSTOM -sslConfiguration -certificateMapMode exactdn -certificateFilter -authentication simple -port 389]')
 
-AdminTask.addIdMgrRepositoryBaseEntry('[-id {{ __ldap_repo }} -name {{ __ldap_realm }} -nameInRepository {{ __ldap_realm }}]')
-AdminTask.addIdMgrRealmBaseEntry('[-name defaultWIMFileBasedRealm -baseEntry {{ __ldap_realm }}]')
+AdminTask.addIdMgrRepositoryBaseEntry('[-id "{{ __ldap_repo }}" -name "{{ __ldap_realm }}" -nameInRepository "{{ __ldap_realm }}"]')
+AdminTask.addIdMgrRealmBaseEntry('[-name defaultWIMFileBasedRealm -baseEntry "{{ __ldap_realm }}"]')
 
 #Add Entity Types, Group attribute definition and external id attributes mapping
 {% if (cnx_setup_mt is defined | default(false) and cnx_setup_mt|bool) or (ldap_setup_internal is defined | default(false) and ldap_setup_internal|bool) %}


### PR DESCRIPTION
If the ldap realm name or ldap bind user contains spaces the playbook fails with the error:

"WASX7017E: Exception received while running file \"/opt/IBM/WebSphere/AppServer/profiles/Dmgr01/bin/was_config_ldap.py\"; exception information: com.ibm.ws.scripting.ScriptingException: WASX8009E: Invalid parameter:"

In the section "Create LDAP repository" all variables enclosed in quotes to avoid such errors.