### PR TITLE
fix missing pyhton3 on dmgr

### DIFF
--- a/roles/hcl/docs/setup-environment/tasks/main.yml
+++ b/roles/hcl/docs/setup-environment/tasks/main.yml
@@ -6,7 +6,7 @@
   include_tasks:           setup_os.yml
   when:
     - __setup_environment|bool
-    - inventory_hostname in groups["docs_servers"] or inventory_hostname in groups["conversion_servers"] or inventory_hostname in groups["viewer_servers"] or inventory_hostname in groups["proxy_servers"]
+    - inventory_hostname in groups["docs_servers"] or inventory_hostname in groups["conversion_servers"] or inventory_hostname in groups["viewer_servers"] or inventory_hostname in groups["proxy_servers"]  or inventory_hostname in groups["dmgr"]
 
 - name:                    Create docs user to setup job target
   include_tasks:           create_docs_user.yml


### PR DESCRIPTION
The missing python3 package on dmgr causes the following error during the extention installation

> TASK [docs : Run the Docs Editor Extension installer (fresh)] ***************************************************************************************************************
> fatal: [dmgr.mydomain.com]: FAILED! => {...... "msg": "non-zero return code", "rc": 127, "start": "2023-08-02 16:25:52.602420", "stderr": "./install.sh: line 17: python3: command not found", "stderr_lines": ["./install.sh: line 17: python3: command not found"], "stdout": "", "stdout_lines": []}