### PR TITLE
check if ansible_domain is empty

### DIFF
--- a/roles/third_party/ibm/wasnd/was-dmgr-config-sso-update/tasks/create_sso_domainnames.yml
+++ b/roles/third_party/ibm/wasnd/was-dmgr-config-sso-update/tasks/create_sso_domainnames.yml
@@ -8,6 +8,14 @@
     __sso_domainnames:  ".{{ ansible_domain }};.{{ __sso_external }}"
   when:
     - ansible_domain != __sso_external
+    - ansible_domain != ""
+
+- name:                 Single domain SSO (empty ansible_domain)
+  set_fact:
+    __sso_domainnames:  ".{{ __sso_external }}"
+  when:
+    - ansible_domain != __sso_external
+    - ansible_domain == ""
 
 - debug: var=__sso_domainnames
   run_once: true


### PR DESCRIPTION
When the ansible fact variable `ansible_domain` is empty the playbook sets the WAS SSO domain as follows: `.;.mydomain.com`

To avoid this setting a check of the ansible variable is added.

Fix #302