### PR TITLE
Update httpd.conf.j2 to match official documention (dont block pageHeader)

### DIFF
--- a/roles/third_party/ibm/ihs/ibm-http-httpdconf/templates/httpd.conf.j2
+++ b/roles/third_party/ibm/ihs/ibm-http-httpdconf/templates/httpd.conf.j2
@@ -1040,10 +1040,6 @@ ProxyPassReverse "/appregistry" "http://{{ __load_balancer_fqdn }}:32080/appregi
 RewriteRule ^/activities/service/html/(.*)$ /boards/activities/service/html/$1 [R]
 {% endif %}
 
-# If used in CNX8, don't allow loading of CNX7 header
-RewriteCond %{HTTP_REFERER} /boards/
-RewriteRule ^/homepage/web/pageHeader - [L,F]
-
 ProxyPass "/boards" "http://{{ __load_balancer_fqdn }}:32080/boards"
 ProxyPassReverse "/boards" "http://{{ __load_balancer_fqdn }}:32080/boards"
 ProxyPass "/api-boards" "http://{{ __load_balancer_fqdn }}:32080/api-boards"

--- a/roles/third_party/ibm/ihs/ibm-http-httpdconf/templates/httpd.conf.j2
+++ b/roles/third_party/ibm/ihs/ibm-http-httpdconf/templates/httpd.conf.j2
@@ -953,10 +953,6 @@ ProxyPassReverse "/appregistry" "http://{{ __load_balancer_fqdn }}:32080/appregi
 RewriteRule ^/activities/service/html/(.*)$ /boards/activities/service/html/$1 [R]
 {% endif %}
 
-# If used in CNX8, don't allow loading of CNX7 header
-RewriteCond %{HTTP_REFERER} /boards/
-RewriteRule ^/homepage/web/pageHeader - [L,F]
-
 ProxyPass "/boards" "http://{{ __load_balancer_fqdn }}:32080/boards"
 ProxyPassReverse "/boards" "http://{{ __load_balancer_fqdn }}:32080/boards"
 ProxyPass "/api-boards" "http://{{ __load_balancer_fqdn }}:32080/api-boards"


### PR DESCRIPTION
remove deprecated/unnecessary step to block pageHeader loading

Please see https://opensource.hcltechsw.com/connections-doc/v8-cr4/admin/install/cp_3p_install_ap_services.html as per case number CS0423391.