### PR TITLE
April CR6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Connections8:
 -r-xr-xr-x   1 root root          66 Aug 22 05:20 HCL_Connections_8.0_lin.tar.sha256
 -r-xr-xr-x   1 root root   661821440 Aug 22 05:20 HCL_Connections_8.0_wizards_lin_aix.tar
 -r-xr-xr-x   1 root root          66 Aug 22 05:20 HCL_Connections_8.0_wizards_lin_aix.tar.sha256
--r-xr-xr-x   1 root root             Jan 26 16:41 HC8.0_CR5.zip
+-r-xr-xr-x   1 root root             Apr 10 16:41 HC8.0_CR6.zip
 
 DB2:
 -rw-r--r--.  1 dmenges dmenges    3993254 Oct 16 13:13 DB2_ESE_AUSI_Activation_11.5.zip

--- a/documentation/VARIABLES.md
+++ b/documentation/VARIABLES.md
@@ -249,6 +249,8 @@ sametime_host | *none* | Sametime server hostname
 sametime_ltpa_files | *none* | LTPA key file to import to WebSphere
 sametime_ltpa_key_password | *none* | Password of the LTPA key file
 cnx_ic360_cluster | Apps | Cluster running IC360
+sharepoint_client_id | *none* - optional | If defined, will configure Sharepoint widget
+sharepoint_tenant_id | *none* - optional | If defined, will configure Sharepoint widget
 
 
 ### Docs Variables
@@ -305,7 +307,7 @@ uninstall_tinyeditors | true | true will uninstall Tiny Editors
 ### Component Pack Infra Variables
 Name | Default | Description
 ---- | --------| -------------
-containerd_version | 1.6.24-3.1.el7 | Containerd version to be installed
+containerd_version | 1.6.26-3.1.el7 | Containerd version to be installed
 docker_version | 20.10.12 | Docker version to be installed
 docker_insecure_registries | {{ docker_registry_url }} | Docker insecure-registries setting
 registry_port | 5000 | The registry defaults to listening on port 5000
@@ -315,7 +317,7 @@ component_pack_helm_repository | https://hclcr.io/chartrepo/cnx | Helm repo url,
 registry_user | admin | Docker Registry user name
 registry_password | password | Docker Registry user password
 overlay2_enabled | true | true enables OverlayFS storage driver
-kubernetes_version | 1.28.4 | Kubernetes version to be installed
+kubernetes_version | 1.29.0 | Kubernetes version to be installed
 kube_binaries_install_dir | /usr/bin | kuberneters binary install directory
 kube_binaries_download_url | https://storage.googleapis.com/kubernetes-release/release | kuberneters binary download path
 ic_internal | localhost | Connections server internal frontend host (eg. IHS host)
@@ -327,7 +329,12 @@ helm_version | 3.11.3 | Helm version to be installed
 haproxy_version | 2.6.6 | HAProxy version to be installed
 haproxy_url | *none* | Alternative HAProxy tar download location
 ssl_root_ca | /C=US/ST=CA/L=Sunnyvale/O=HCL America Inc/OU=Software/CN=hcltechsw.com | SSL Root CA Certificate
-
+build_nginx | true | true will build and install NGINX with headers-more-nginx-module to allow removal of Server information from header
+nginx_install_dir | /etc/nginx | NGINX install location
+nginx_logs_dir | /var/log/nginx | NGINX logs location
+nginx_pid_loc | /run/nginx.pid | Used when build_nginx=true, NGINX pid file location
+nginx_exec_path | /usr/sbin/nginx | Used when build_nginx=true, NGINX executable location
+nginx_user | nginx | User to run the NGINX process
 
 ### Component Pack Variables
 Name | Default | Description
@@ -364,7 +371,6 @@ setup_customizer | true | True will deploy mw-proxy and setup customizations
 elasticsearch_default_version | 7 | Default ElasticSearch version
 elasticsearch_default_port | 30098 | ElasticSearch port
 elasticsearch_replica_count | 3 | Replica count to set in Helm charts for Elasticsearch
-elasticsearch_auto_expand_replicas | *none* | Whether the ElasticSearch cluster should automatically add replica shards based on the number of data nodes. Specify a lower bound and upper limit (for example, 0–9) or all for the upper limit. For example, if you have 5 data nodes and set index.auto_expand_replicas to 0–3, then the cluster does not automatically add another replica shard. However, if you set this value to 0-all and add 2 more nodes for a total of 7, the cluster will expand to now have 6 replica shards
 setup_elasticsearch | false | True will deploy ElasticSearch 5 (for Connections 6.5CR1)
 setup_elasticsearch7 | false | True will deploy ElasticSearch 7 (for Connections 7)
 setup_opensearch | True | True will deploy OpenSearch
@@ -404,6 +410,7 @@ opensearch_watermark_flood_stage | none | Controls the flood stage watermark for
 opensearch_watermark_high | *none* | Controls the high watermark for disk usage for opensearch. Make sure that the opensearch_watermark_flood_stage is more than or equal to opensearch_watermark_high
 opensearch_watermark_low | *none* | Controls the low watermark for disk usage for opensearch. Make sure that the opensearch_watermark_high is more than or equal to opensearch_watermark_low
 opensearch_auto_expand_replicas | *none* | Whether the OpenSearch cluster should automatically add replica shards based on the number of data nodes. Specify a lower bound and upper limit (for example, 0–9) or all for the upper limit. For example, if you have 5 data nodes and set index.auto_expand_replicas to 0–3, then the cluster does not automatically add another replica shard. However, if you set this value to 0-all and add 2 more nodes for a total of 7, the cluster will expand to now have 6 replica shards
+elasticsearch_auto_expand_replicas | *none* | Whether the ElasticSearch cluster should automatically add replica shards based on the number of data nodes. Specify a lower bound and upper limit (for example, 0–9) or all for the upper limit. For example, if you have 5 data nodes and set index.auto_expand_replicas to 0–3, then the cluster does not automatically add another replica shard. However, if you set this value to 0-all and add 2 more nodes for a total of 7, the cluster will expand to now have 6 replica shards
 
 ### NFS Variables
 Name | Default | Description

--- a/documentation/howtos/connections_upgrade_to_8.x.md
+++ b/documentation/howtos/connections_upgrade_to_8.x.md
@@ -125,7 +125,7 @@ kubectl delete ingress -n connections $(kubectl get ingress -n connections | awk
 >Ensure you reconfigure NFS by running playbook playbooks/third_party/setup-nfs.yml.
 </details>
 
-Follow [Kubernetes official document](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/) on how to upgrade kubernetes version. Kubernetes can be upgraded to the next minor version using below playbook.  Do NOT skip MINOR versions when upgrading Kubernetes.   For example, if you are upgrading from 1.26 -> 1.28, it needs to be upgraded from 1.26 -> 1.27 -> 1.28.  Add 'upgrade_version' variable in the [inventory file](https://github.com/HCL-TECH-SOFTWARE/connections-automation/blob/main/environments/examples/cnx8/db2/group_vars/all.yml) to the target version and adjust before running the playbook each time:
+Follow [Kubernetes official document](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/) on how to upgrade kubernetes version. Kubernetes can be upgraded to the next minor version using below playbook.  Do NOT skip MINOR versions when upgrading Kubernetes.   For example, if you are upgrading from 1.27 -> 1.29, it needs to be upgraded from 1.27 -> 1.28 -> 1.29.  Add 'upgrade_version' variable in the [inventory file](https://github.com/HCL-TECH-SOFTWARE/connections-automation/blob/main/environments/examples/cnx8/db2/group_vars/all.yml) to the target version and adjust before running the playbook each time:
 
 ```
 ansible-playbook -i environments/examples/cnx8/db2/inventory.ini playbooks/third_party/kubernetes/upgrade-kubernetes.yml

--- a/environments/examples/cnx8/db2/group_vars/all.yml
+++ b/environments/examples/cnx8/db2/group_vars/all.yml
@@ -49,9 +49,9 @@ cnx_repository_url:                              "http://{{ groups['installer'][
 tinyeditors_download_location:                   http://{{ groups['installer'][0] }}:8001/TinyEditors
 cnx_fixes_repository_url:                        "http://{{ groups['installer'][0] }}:8001/{{ connections_kit_folder }}"
 
-cnx_fixes_version:                               "8.0.0.0_CR5"
+cnx_fixes_version:                               "8.0.0.0_CR6"
 cnx_fixes_files:
-  - { file_name: "HC8.0_CR5.zip" }
+  - { file_name: "HC8.0_CR6.zip" }
 
 cnx_package:                                     "HCL_Connections_8.0_lin.tar"
 connections_wizards_package_name:                "HCL_Connections_8.0_wizards_lin_aix.tar"

--- a/environments/examples/cnx8/oracle/group_vars/all.yml
+++ b/environments/examples/cnx8/oracle/group_vars/all.yml
@@ -49,9 +49,9 @@ cnx_repository_url:                              "http://{{ groups['installer'][
 tinyeditors_download_location:                   http://{{ groups['installer'][0] }}:8001/TinyEditors
 cnx_fixes_repository_url:                        "http://{{ groups['installer'][0] }}:8001/{{ connections_kit_folder }}"
 
-cnx_fixes_version:                               "8.0.0.0_CR5"
+cnx_fixes_version:                               "8.0.0.0_CR6"
 cnx_fixes_files:
-  - { file_name: "HC8.0_CR5.zip" }
+  - { file_name: "HC8.0_CR6.zip" }
 
 cnx_package:                                     "HCL_Connections_8.0_lin.tar"
 connections_wizards_package_name:                "HCL_Connections_8.0_wizards_lin_aix.tar"

--- a/environments/examples/cnx8/quick_start/group_vars/all.yml
+++ b/environments/examples/cnx8/quick_start/group_vars/all.yml
@@ -49,9 +49,9 @@ cnx_repository_url:                              "http://{{ groups['installer'][
 tinyeditors_download_location:                   http://{{ groups['installer'][0] }}:8001/TinyEditors
 cnx_fixes_repository_url:                        "http://{{ groups['installer'][0] }}:8001/{{ connections_kit_folder }}"
 
-cnx_fixes_version:                               "8.0.0.0_CR5"
+cnx_fixes_version:                               "8.0.0.0_CR6"
 cnx_fixes_files:
-  - { file_name: "HC8.0_CR5.zip" }
+  - { file_name: "HC8.0_CR6.zip" }
 
 cnx_package:                                     "HCL_Connections_8.0_lin.tar"
 connections_wizards_package_name:                "HCL_Connections_8.0_wizards_lin_aix.tar"

--- a/environments/examples/existing_database/db2/group_vars/all.yml
+++ b/environments/examples/existing_database/db2/group_vars/all.yml
@@ -49,9 +49,9 @@ cnx_repository_url:                              "http://{{ groups['installer'][
 tinyeditors_download_location:                   http://{{ groups['installer'][0] }}:8001/TinyEditors
 cnx_fixes_repository_url:                        "http://{{ groups['installer'][0] }}:8001/{{ connections_kit_folder }}"
 
-cnx_fixes_version:                               "8.0.0.0_CR5"
+cnx_fixes_version:                               "8.0.0.0_CR6"
 cnx_fixes_files:
-  - { file_name: "HC8.0_CR5.zip" }
+  - { file_name: "HC8.0_CR6.zip" }
 
 cnx_package:                                     "HCL_Connections_8.0_lin.tar"
 connections_wizards_package_name:                "HCL_Connections_8.0_wizards_lin_aix.tar"

--- a/environments/examples/existing_database/mssql/group_vars/all.yml
+++ b/environments/examples/existing_database/mssql/group_vars/all.yml
@@ -49,9 +49,9 @@ cnx_repository_url:                              "http://{{ groups['installer'][
 tinyeditors_download_location:                   http://{{ groups['installer'][0] }}:8001/TinyEditors
 cnx_fixes_repository_url:                        "http://{{ groups['installer'][0] }}:8001/{{ connections_kit_folder }}"
 
-cnx_fixes_version:                               "8.0.0.0_CR5"
+cnx_fixes_version:                               "8.0.0.0_CR6"
 cnx_fixes_files:
-  - { file_name: "HC8.0_CR5.zip" }
+  - { file_name: "HC8.0_CR6.zip" }
 
 cnx_package:                                     "HCL_Connections_8.0_lin.tar"
 connections_wizards_package_name:                "HCL_Connections_8.0_wizards_lin_aix.tar"

--- a/environments/examples/existing_database/oracle/group_vars/all.yml
+++ b/environments/examples/existing_database/oracle/group_vars/all.yml
@@ -49,9 +49,9 @@ cnx_repository_url:                              "http://{{ groups['installer'][
 tinyeditors_download_location:                   http://{{ groups['installer'][0] }}:8001/TinyEditors
 cnx_fixes_repository_url:                        "http://{{ groups['installer'][0] }}:8001/{{ connections_kit_folder }}"
 
-cnx_fixes_version:                               "8.0.0.0_CR5"
+cnx_fixes_version:                               "8.0.0.0_CR6"
 cnx_fixes_files:
-  - { file_name: "HC8.0_CR5.zip" }
+  - { file_name: "HC8.0_CR6.zip" }
 
 cnx_package:                                     "HCL_Connections_8.0_lin.tar"
 connections_wizards_package_name:                "HCL_Connections_8.0_wizards_lin_aix.tar"

--- a/roles/hcl/component-pack-harbor/vars/main.yml
+++ b/roles/hcl/component-pack-harbor/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-__kubernetes_version:                        "{{ kubernetes_version | default('1.28.4') }}"
+__kubernetes_version:                        "{{ kubernetes_version | default('1.29.0') }}"
 __python_path:                               "{{ python_path | default('/usr/bin/python3') }}"
 __ansible_cache:                             "/tmp/k8s_ansible"
 __sudo_user:                                 "{{ kubectl_user | default( ansible_env['SUDO_USER'] ) }}"

--- a/roles/hcl/component-pack/tasks/setup_installation.yml
+++ b/roles/hcl/component-pack/tasks/setup_installation.yml
@@ -36,6 +36,7 @@
     src:                 "{{ __download_location }}/{{ __package_name }}"
     dest:                "{{ __extraction_folder }}"
     remote_src:          yes
+    validate_certs:      false
   register: download_and_unpack_component_pack
   until: download_and_unpack_component_pack is succeeded
   retries: 3

--- a/roles/hcl/connections-wizards/tasks/setup_connections_docs.yml
+++ b/roles/hcl/connections-wizards/tasks/setup_connections_docs.yml
@@ -29,6 +29,7 @@
     src:                 "{{ __docs_download_location }}/{{ __docs_package_name }}"
     dest:                "{{ __docs_extraction_folder }}"
     remote_src:          yes
+    validate_certs:      false
   when:
     - not docs_database_already_created.stat.exists
 

--- a/roles/hcl/connections-wizards/tasks/setup_connections_docs_mssql.yml
+++ b/roles/hcl/connections-wizards/tasks/setup_connections_docs_mssql.yml
@@ -29,6 +29,7 @@
     src:                 "{{ __docs_download_location }}/{{ __docs_package_name }}"
     dest:                "{{ __docs_extraction_folder }}"
     remote_src:          yes
+    validate_certs:      false
   when:
     - not docs_migrations_already_done.stat.exists
 

--- a/roles/hcl/connections-wizards/tasks/setup_connections_wizards.yml
+++ b/roles/hcl/connections-wizards/tasks/setup_connections_wizards.yml
@@ -23,6 +23,7 @@
     src:                 "{{ __download_location }}/{{ __package_name }}"
     dest:                "{{ __db_extraction_folder }}"
     remote_src:          yes
+    validate_certs:      false
   when:
     - (not migrations_already_done.stat.exists) or (__cnx_force_repopulation |bool) or (__db_enable_upgrades |bool)
   retries:               3

--- a/roles/hcl/connections-wizards/tasks/setup_connections_wizards_mssql.yml
+++ b/roles/hcl/connections-wizards/tasks/setup_connections_wizards_mssql.yml
@@ -23,6 +23,7 @@
     src:                 "{{ __download_location }}/{{ __package_name }}"
     dest:                "{{ __db_extraction_folder }}"
     remote_src:          yes
+    validate_certs:      false
   when:
     - (not migrations_already_done.stat.exists) or (__cnx_force_repopulation |bool) or (__db_enable_upgrades |bool)
   retries:               3

--- a/roles/hcl/connections/ifix/tasks/download_extract_upgradeinstaller.yml
+++ b/roles/hcl/connections/ifix/tasks/download_extract_upgradeinstaller.yml
@@ -16,12 +16,14 @@
     url:                   "{{ cnx_repository_url }}/{{ __cnx_ifix_installer }}"
     dest:                  "{{ __tmp_dir }}/cnx-ifix/{{ __cnx_ifix_installer }}"
     mode:                  0755
+    validate_certs:        false
 
 - name:                    Extract the updateInstaller
   unarchive:
     src:                   "{{ __tmp_dir }}/cnx-ifix/{{ __cnx_ifix_installer }}"
     dest:                  "{{ __cnx_install_location }}/updateInstaller"
     copy:                  no
+    validate_certs:        false
   register:                download_and_unpack_connections_upgradeinstaller
   until:                   download_and_unpack_connections_upgradeinstaller is succeeded
   retries: 3
@@ -47,3 +49,4 @@
     url:                   "{{ cnx_repository_url }}/{{ ifix_file }}"
     dest:                  "{{ __cnx_install_location }}/updateInstaller/fixes"
     mode:                  0755
+    validate_certs:        false

--- a/roles/hcl/connections/post_install_config/tasks/setup_sharepoint_widget.yml
+++ b/roles/hcl/connections/post_install_config/tasks/setup_sharepoint_widget.yml
@@ -5,5 +5,6 @@
       regexp: "{{ item.regexp1 }}"
       replace: "{{ item.replace }}"
     with_items:
-      - { path: '{{ __widgets_config_file }}', regexp1: 'value="{clientId}"', replace: 'value="{{ __sharepoint_client_id }}"'}
-      - { path: '{{ __widgets_config_file }}', regexp1: 'value="{tenant}"', replace: 'value="{{ __sharepoint_tenant_id }}"'}
+      - { path: '{{ __widgets_config_file }}', regexp1: 'value="{clientId}"', replace: 'value="{{ sharepoint_client_id }}"'}
+      - { path: '{{ __widgets_config_file }}', regexp1: 'value="{tenant}"', replace: 'value="{{ sharepoint_tenant_id }}"'}
+    when: sharepoint_client_id is defined and sharepoint_tenant_id is defined

--- a/roles/hcl/connections/post_install_config/vars/main.yml
+++ b/roles/hcl/connections/post_install_config/vars/main.yml
@@ -73,10 +73,6 @@ __selfreg_ldap_guid_xpath:          "/config/ldap-connector/external-user-server
 __selfreg_profile_base_guid_xpath:  "/config/profiles-connector/entry/attributes/attribute[key='com.ibm.snx_profiles.base.guid']/value"
 __cnx_enable_invite:                "{{ cnx_enable_invite | default('false') }}"
 
-# Sharepoint Widget Configuration
-__sharepoint_client_id:              "{{ sharepoint_client_id | default('c14ed562-5a27-4723-82b6-62cca82d2fcc') }}"
-__sharepoint_tenant_id:              "{{ sharepoint_tenant_id | default('b799d683-9a83-4044-a827-c88e16238a7b') }}"
-
 # Files - files-config.xml
 __filescfg_full_path:               "{{ __was_install_location }}/profiles/{{ __profile_name }}/config/cells/{{ __was_cellname }}/LotusConnections-config/files-config.xml"
 __filescfg_namespaces:

--- a/roles/hcl/connections/set_all_auth_role/tasks/main.yml
+++ b/roles/hcl/connections/set_all_auth_role/tasks/main.yml
@@ -141,6 +141,7 @@
     __app:                   "{{ item }}"
     __role_mapping_prop:
       - { __role: "READER", __everyone: "no", __allauth: "{{ __allauth_value }}", __users: '""', __groups: '""', __allauth_trusted: "{{ __allauth_trusted_value }}", __mappeduseraccessids: '""', __mappedgroupaccessids: '""' }
+      - { __role: "CEC-READER", __everyone: "no", __allauth: "{{ __allauth_value }}", __users: '""', __groups: '""', __allauth_trusted: "{{ __allauth_trusted_value }}", __mappeduseraccessids: '""', __mappedgroupaccessids: '""' }
   with_items:
     - ICEC
   when:

--- a/roles/hcl/connections/tasks/download_connections_installer.yml
+++ b/roles/hcl/connections/tasks/download_connections_installer.yml
@@ -41,7 +41,8 @@
       get_url:
         url:              "{{ cnx_repository_url }}/{{ __cnx_package }}"
         dest:             "{{ __tmp_dir }}/cnx"
-        timeout:          300 
+        timeout:          300
+        validate_certs:   false 
 
     - name:               "Calculate checksum of {{ __tmp_dir }}/cnx/{{ __cnx_package }}"
       shell:              sha256sum "{{ __tmp_dir }}/cnx"/"{{ __cnx_package }}" | cut -d' ' -f1

--- a/roles/hcl/connections/tasks/download_extract_connections.yml
+++ b/roles/hcl/connections/tasks/download_extract_connections.yml
@@ -37,6 +37,7 @@
     url:             "{{ cnx_repository_url }}/{{ item.file_name }}"
     dest:            "{{ __tmp_dir }}/cnx/{{ item.file_name }}"
     mode:            0755
+    validate_certs:  false
   with_items:        "{{ __ccm_files }}"
   when:              (ccm_install is defined)
 
@@ -45,6 +46,7 @@
     url:             "{{ cnx_fixes_repository_url }}/{{ item.file_name }}"
     dest:            "{{ __tmp_dir }}/cnx-cr/{{ item.file_name }}"
     mode:            0755
+    validate_certs:  false
   with_items:        "{{ __cnx_fixes_files }}"
   when:             (__cnx_fixes_version != '')
 

--- a/roles/hcl/docs/tasks/download_docs.yml
+++ b/roles/hcl/docs/tasks/download_docs.yml
@@ -13,6 +13,7 @@
     src:                 "{{ __download_location }}/{{ __package_name }}"
     dest:                "{{ __extraction_folder }}"
     remote_src:          yes
+    validate_certs:      false
   register: download_and_unpack_docs
   until: download_and_unpack_docs is succeeded
   retries: 3

--- a/roles/hcl/docs/unpack_docs_installer/tasks/main.yml
+++ b/roles/hcl/docs/unpack_docs_installer/tasks/main.yml
@@ -14,6 +14,7 @@
     src:                 "{{ app_zip_name.files[0].path }}"
     dest:                "{{ __extraction_folder }}/{{ __app_name }}"
     remote_src:          yes
+    validate_certs:      false
   register:              unpacked_zip
   until:                 unpacked_zip is succeeded
 

--- a/roles/third_party/containerd-install/vars/main.yml
+++ b/roles/third_party/containerd-install/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-__containerd_default_version:                          "1.6.24-3.1.el{{ ansible_distribution_major_version }}"
+__containerd_default_version:                          "1.6.26-3.1.el{{ ansible_distribution_major_version }}"
 __containerd_version:                                  "{{ containerd_version | default( __containerd_default_version ) }}"
 
 __modules_containerd_conf_template:                    "containerd.conf.j2"

--- a/roles/third_party/haproxy-install/tasks/download_and_build_haproxy.yml
+++ b/roles/third_party/haproxy-install/tasks/download_and_build_haproxy.yml
@@ -13,6 +13,7 @@
 - name:                   Build Haproxy target with params
   make:
     chdir:                "{{ __haproxy_download_dir }}"
+    target:               all
     params:
       TARGET:             linux_glibc
       USE_PCRE:           1

--- a/roles/third_party/ibm/ihs/ibm-http-config-plgwct/tasks/config_plgwct.yml
+++ b/roles/third_party/ibm/ihs/ibm-http-config-plgwct/tasks/config_plgwct.yml
@@ -39,15 +39,27 @@
     dest:               "/tmp/wct_plugins_{{ __ihs_hostname }}.zip"
     format:             zip
 
-- name:                 Synchronize /tmp/wct_plugins_{{ __ihs_hostname }}.zip with {{ dmgr_hostname }}
-  synchronize:
+- name:                 Copy wct_plugins_{{ __ihs_hostname }}.zip to local
+  fetch:
     src:                "/tmp/wct_plugins_{{ __ihs_hostname }}.zip"
-    dest:               /tmp/
-    mode:               pull
+    dest:               "/tmp/wct_plugins_{{ __ihs_hostname }}-{{ ansible_date_time.iso8601_basic_short }}.zip"
+    flat:               yes
+  become:               false
+
+- name:                 Copy wct_plugins_{{ __ihs_hostname }}.zip from local to {{ dmgr_hostname }}
+  copy:
+    src:                "/tmp/wct_plugins_{{ __ihs_hostname }}-{{ ansible_date_time.iso8601_basic_short }}.zip"
+    dest:               "/tmp/wct_plugins_{{ __ihs_hostname }}.zip"
   delegate_to:          "{{ dmgr_hostname }}"
   become:               false
 
-- name:                 Remove /tmp/wct_plugins_{{ __ihs_hostname }} if it already exists
+- name:                 Remove /tmp/wct_plugins_{{ __ihs_hostname }}-{{ ansible_date_time.iso8601_basic_short }}.zip from local
+  file:
+    path:               "/tmp/wct_plugins_{{ __ihs_hostname }}-{{ ansible_date_time.iso8601_basic_short }}.zip"
+    state:              absent
+  become:               false
+
+- name:                 Remove /tmp/wct_plugins_{{ __ihs_hostname }} folder if it already exists
   file:
     path:               "/tmp/wct_plugins_{{ __ihs_hostname }}"
     state:              absent
@@ -125,11 +137,24 @@
     format:             zip
   delegate_to:          "{{ dmgr_hostname }}"
 
-- name:                 Synchronize /tmp/wct_generated_plugins_{{ __ihs_hostname }}.zip from {{ dmgr_hostname }} to {{ inventory_hostname }}
-  synchronize:
-    src:                /tmp/wct_generated_plugins_{{ __ihs_hostname }}.zip
-    dest:               /tmp/
+- name:                 Copy /tmp/wct_generated_plugins_{{ __ihs_hostname }}.zip from dmgr to local
+  fetch:
+    src:                "/tmp/wct_generated_plugins_{{ __ihs_hostname }}.zip"
+    dest:               "/tmp/wct_generated_plugins_{{ __ihs_hostname }}-{{ ansible_date_time.iso8601_basic_short }}.zip"
+    flat:               yes
   delegate_to:          "{{ dmgr_hostname }}"
+  become:               false
+
+- name:                 Copy /tmp/wct_generated_plugins_{{ __ihs_hostname }}.zip from local to {{ inventory_hostname }}
+  copy:
+    src:                "/tmp/wct_generated_plugins_{{ __ihs_hostname }}-{{ ansible_date_time.iso8601_basic_short }}.zip"
+    dest:               "/tmp/wct_generated_plugins_{{ __ihs_hostname }}.zip"
+  become:               false
+
+- name:                 Remove /tmp/wct_generated_plugins_{{ __ihs_hostname }}-{{ ansible_date_time.iso8601_basic_short }}.zip from local
+  file:
+    path:               "/tmp/wct_generated_plugins_{{ __ihs_hostname }}-{{ ansible_date_time.iso8601_basic_short }}.zip"
+    state:              absent
   become:               false
 
 - name:                 Extract /tmp/wct_generated_plugins_{{ __ihs_hostname }}.zip on {{ inventory_hostname }}

--- a/roles/third_party/ibm/ihs/ibm-http-server-fix-install/tasks/install_ihs_fixes.yml
+++ b/roles/third_party/ibm/ihs/ibm-http-server-fix-install/tasks/install_ihs_fixes.yml
@@ -18,6 +18,7 @@
     src:         "{{ __repository_url }}/{{ item.file_name }}"
     dest:        "{{ __tmp_dir }}/wassup_fixes"
     remote_src:  yes
+    validate_certs:  false
   with_items:    "{{ __ihs_fp_files }}"
 
 - name:          Extract WAS WCT FP Files
@@ -25,6 +26,7 @@
     src:         "{{ __repository_url }}/{{ item.file_name }}"
     dest:        "{{ __tmp_dir }}/wctfixes"
     remote_src:  yes
+    validate_certs:  false
   with_items:    "{{ __wct_fp_files }}"
 
 - name:          Generate Response file

--- a/roles/third_party/ibm/ihs/ibm-http-server-install/tasks/install_ihs.yml
+++ b/roles/third_party/ibm/ihs/ibm-http-server-install/tasks/install_ihs.yml
@@ -15,6 +15,7 @@
     url:         "{{ __repository_url }}/{{ item.file_name }}"
     dest:        "{{ __tmp_dir }}/{{ item.file_name }}"
     mode:        0755
+    validate_certs: false
   with_items:    "{{ __this_files }}"
 
 - name:          Extract IBM HTTP Server Files

--- a/roles/third_party/ibm/installation-manager-install/tasks/install_iim.yml
+++ b/roles/third_party/ibm/installation-manager-install/tasks/install_iim.yml
@@ -10,6 +10,7 @@
     url:         "{{ iim_repository_url }}/{{ __bin_file }}"
     dest:        "{{ __tmp_dir }}/{{ __bin_file }}"
     mode:        0755
+    validate_certs: false
 
 - name:          Extract IBM Installation Manager
   unarchive:

--- a/roles/third_party/ibm/tdi-install/tasks/tdi_install.yml
+++ b/roles/third_party/ibm/tdi-install/tasks/tdi_install.yml
@@ -22,6 +22,7 @@
     src:                 "{{ __download_location }}/{{ __package_name }}"
     dest:                "{{ __extraction_folder }}"
     remote_src:          yes
+    validate_certs:      false
   when:
     - not tdi_already_installed.stat.exists
 

--- a/roles/third_party/ibm/tdi-install/tasks/tdi_upgrade.yml
+++ b/roles/third_party/ibm/tdi-install/tasks/tdi_upgrade.yml
@@ -58,6 +58,7 @@
     src:                 "{{ __download_location }}/{{ __upgrade_package_name }}"
     dest:                "{{ fp_extracted_folder | default( __tdi_upgrade_folder ) }}"
     remote_src:          yes
+    validate_certs:      false
   when:
     - tdi_already_installed.stat.exists |bool
     - tdi_already_upgraded is not defined

--- a/roles/third_party/ibm/tdi-install/tasks/tdisol_install.yml
+++ b/roles/third_party/ibm/tdi-install/tasks/tdisol_install.yml
@@ -61,6 +61,7 @@
     src:                 "{{ __tdi_sol_location }}"
     dest:                "{{ __tdi_sol_dest }}"
     remote_src:          yes
+    validate_certs:      false
   when:
     - __cnx_updates_enabled  |bool or tdi_sol_location is defined
   register: download_and_unpack_tdisol
@@ -117,6 +118,7 @@
     url:                 "{{ __oracle_download_location }}/{{ item }}"
     dest:                "{{ __jdbc_destination }}"
     mode:                0755
+    validate_certs:      false
   with_items:
    - "ojdbc7.jar"
   when:
@@ -128,6 +130,7 @@
     url:                 "{{ __oracle_download_location }}/{{ item }}"
     dest:                "{{ __jdbc_destination }}"
     mode:                0755
+    validate_certs:      false
   with_items:
    - "ojdbc8.jar"
   when:

--- a/roles/third_party/ibm/tdi-install/tasks/upgrade-tdi-jre.yml
+++ b/roles/third_party/ibm/tdi-install/tasks/upgrade-tdi-jre.yml
@@ -3,7 +3,7 @@
     path:                   "{{ __tdi_installed_success_file }}"
   register:                 tdi_already_installed
 
-- name:                     Checking existing dir for jre 
+- name:                     Checking existing dir for jre
   stat:                     path="{{ __tdi_user_install_dir }}/jvm/jre"
   register:                 jre_stat
   when:
@@ -34,6 +34,7 @@
     dest:                   "{{ __tmp_extraction_folder }}"
     remote_src:             yes
     mode:                   0755
+    validate_certs:         false
   when:
     - jre_stat.stat.exists
     - tdi_already_installed.stat.exists

--- a/roles/third_party/ibm/wasnd/was-dmgr-stop-cluster/tasks/main.yml
+++ b/roles/third_party/ibm/wasnd/was-dmgr-stop-cluster/tasks/main.yml
@@ -39,6 +39,13 @@
   until: cout is not search("is already in progress")
   when:                 pool_server is not defined
 
+- name:                 "Kill process in pid file if the cluster is not shutdown after three attempts"
+  shell:                "kill -9 $(cat '{{ __was_install_location }}/profiles/{{ __app_profile_name }}/logs/{{ item }}-{{ inventory_hostname_short }}/{{ item }}-{{ inventory_hostname_short }}.pid')"
+  register:             cout
+  ignore_errors:        true
+  loop:                 "{{ __cluster_name.split(' ') }}"
+  when:                 pool_server is not defined
+
 - name:                 Verify if server is running (pool server)
   shell:                "fuser 2809/tcp"
   register:             server_is_running

--- a/roles/third_party/ibm/wasnd/was-dmgr-stop-cluster/vars/main.yml
+++ b/roles/third_party/ibm/wasnd/was-dmgr-stop-cluster/vars/main.yml
@@ -1,5 +1,7 @@
 ---
 __profile_name:         "{{ profile_name | default('Dmgr01') }}"
+__app_profile_name:     "{{ app_profile_name | default('AppSrv01') }}"
+__serverName:           "{{ __cluster_name }}-{{ inventory_hostname_short }}"
 __was_install_location: "{{ was_install_location  | default('/opt/IBM/WebSphere/AppServer') }}"
 __was_username:         "{{ was_username }}"
 __was_password:         "{{ was_password }}"

--- a/roles/third_party/ibm/wasnd/was-dmgr-update-oauth-app/tasks/main.yml
+++ b/roles/third_party/ibm/wasnd/was-dmgr-update-oauth-app/tasks/main.yml
@@ -10,3 +10,5 @@
         {{ __bin_dir }}/wsadmin.sh -lang jython -port {{ __dmgr_soap_port }} -username {{ __was_username }} -password {{ __was_password }} -f {{ __rsp_file }}
       register:             cout
       changed_when:         cout.rc == 0
+      retries: 3
+      until: cout.rc == 0

--- a/roles/third_party/ibm/wasnd/was-java-install/tasks/install_java.yml
+++ b/roles/third_party/ibm/wasnd/was-java-install/tasks/install_java.yml
@@ -17,6 +17,7 @@
     url:         "{{ was_repository_url }}/{{ item.file_name }}"
     dest:        "{{ __tmp_dir }}/{{ item.file_name }}"
     mode:        0755
+    validate_certs:  false
   with_items:    "{{ __was_java_files }}"
   when:          version_already_installed.rc != 0
 
@@ -25,6 +26,7 @@
     src:         "{{ __tmp_dir }}/{{ item.file_name }}"
     dest:        "{{ __tmp_dir }}/"
     copy:        no
+    validate_certs:  false
   with_items:    "{{ __was_java_files }}"
   when:          version_already_installed.rc != 0
 

--- a/roles/third_party/ibm/wasnd/was-nd-fix-install/tasks/install_was_fixes.yml
+++ b/roles/third_party/ibm/wasnd/was-nd-fix-install/tasks/install_was_fixes.yml
@@ -17,6 +17,7 @@
     src:             "{{ was_fixes_repository_url }}/{{ item.file_name }}"
     dest:            "{{ __tmp_dir }}/"
     remote_src:      yes
+    validate_certs:  false
   with_items:        "{{ __was_fixes_files }}"
   when:              version_already_installed.rc != 0
 

--- a/roles/third_party/ibm/wasnd/was-nd-install/tasks/install_was.yml
+++ b/roles/third_party/ibm/wasnd/was-nd-install/tasks/install_was.yml
@@ -15,6 +15,7 @@
     url:         "{{ was_repository_url }}/{{ item.file_name }}"
     dest:        "{{ __tmp_dir }}/{{ item.file_name }}"
     mode:        0755
+    validate_certs:  false
   with_items:    "{{ __was_files }}"
 
 - name:          Extract WAS ND V8.5.5 Files
@@ -22,6 +23,7 @@
     src:         "{{ __tmp_dir }}/{{ item.file_name }}"
     dest:        "{{ __tmp_dir }}/"
     copy:        no
+    validate_certs:  false
   with_items:    "{{ __was_files }}"
 
 - name:          Generate WAS Response file

--- a/roles/third_party/kubernetes/join-master-nodes/vars/main.yml
+++ b/roles/third_party/kubernetes/join-master-nodes/vars/main.yml
@@ -3,7 +3,7 @@ __ansible_cache:                                           "/tmp/k8s_ansible"
 __etcd_second_node_clustering_success_file:                "{{ __ansible_cache }}/etcd.second.node.clustering.success"
 __etcd_third_node_clustering_success_file:                 "{{ __ansible_cache }}/etcd.third.node.clustering.success"
 
-__kubernetes_version:                                      "{{ kubernetes_version | default('1.28.4') }}"
+__kubernetes_version:                                      "{{ kubernetes_version | default('1.29.0') }}"
 
 __join_command_template:                                   "join.command.j2"
 __join_command_location:                                   "{{ __ansible_cache }}/.join-command-control-plane"

--- a/roles/third_party/kubernetes/kubernetes-install/tasks/prepare_for_k8s.yml
+++ b/roles/third_party/kubernetes/kubernetes-install/tasks/prepare_for_k8s.yml
@@ -20,8 +20,7 @@
 
 - name:              Mount everything if something is missing
   command:           mount -a
-  args:
-    warn:            no
+  
 
 - name:              Enable Kubernetes repository
   template:

--- a/roles/third_party/kubernetes/kubernetes-install/vars/main.yml
+++ b/roles/third_party/kubernetes/kubernetes-install/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-__kubernetes_version:                                "{{ kubernetes_version | default('1.28.4') }}"
+__kubernetes_version:                                "{{ kubernetes_version | default('1.29.0') }}"
 __kubernetes_major_minor_version:                    "{{ __kubernetes_version.split('.')[0:2] | join('.') }}"
 __ansible_cache:                                     "/tmp/k8s_ansible"
 

--- a/roles/third_party/kubernetes/kubernetes-upgrade/vars/main.yml
+++ b/roles/third_party/kubernetes/kubernetes-upgrade/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-__kubernetes_version:           "{{ upgrade_version | default('1.28.4') }}"
+__kubernetes_version:           "{{ upgrade_version | default('1.29.0') }}"
 __kubernetes_major_minor_version: "{{ __kubernetes_version.split('.')[0:2] | join('.') }}"
 
 __ansible_cache:                "/tmp/k8s_ansible"

--- a/roles/third_party/kubernetes/setup-master-node/vars/main.yml
+++ b/roles/third_party/kubernetes/setup-master-node/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-__kubernetes_version:           "{{ kubernetes_version | default('1.28.4') }}"
+__kubernetes_version:           "{{ kubernetes_version | default('1.29.0') }}"
 
 __ansible_cache:                "/tmp/k8s_ansible"
 

--- a/roles/third_party/ldap-install/tasks/install_openldap.yml
+++ b/roles/third_party/ldap-install/tasks/install_openldap.yml
@@ -26,10 +26,15 @@
   when:
     - ansible_distribution == "AlmaLinux"
 
+- name:                     "Verify if database is already created"
+  stat:
+    path:                   "{{ __db_ldif_success_file }}"
+  register:                 ldap_database_already_created
+
 - name:                     Install OpenLDAP and dependencies on RHEL
   include_tasks:            install_symas_openldap.yml
   when:
-    - ansible_distribution == "RedHat"
+    - ansible_distribution == "RedHat" and not ldap_database_already_created.stat.exists
 
 - name:                     Start slapd service
   service:
@@ -42,11 +47,6 @@
   command:                  "chkconfig slapd on"
   when:
     - ansible_distribution == "RedHat"
-
-- name:                     "Verify if database is already created"
-  stat:
-    path:                   "{{ __db_ldif_success_file }}"
-  register:                 ldap_database_already_created
 
 - name:                     Create get slappasswd command for Non-RedHat distribution
   set_fact:

--- a/roles/third_party/mssql-install/tasks/setup_jdbc.yml
+++ b/roles/third_party/mssql-install/tasks/setup_jdbc.yml
@@ -9,12 +9,14 @@
     src:                 "{{ __download_location }}/{{ __package_name }}"
     dest:                "{{ __jdbc_installation_folder }}"
     remote_src:          yes
+    validate_certs:      false
 
 - name:                  Download and unzip legacy drivers to the {{ __jdbc_installation_folder }} for TDI JRE 7
   unarchive:
     src:                 "{{ __download_location }}/{{ item }}"
     dest:                "{{ __jdbc_installation_folder }}"
     remote_src:          yes
+    validate_certs:      false
   with_items:
     - "{{ __package_name_legacy }}"
 #    - "{{ __package_name_legacy_40 }}"

--- a/roles/third_party/nginx-install/tasks/configure_customizer.yml
+++ b/roles/third_party/nginx-install/tasks/configure_customizer.yml
@@ -1,3 +1,8 @@
+- name:                      Create {{ __conf_d_location }}
+  file:
+    path:                    "{{ __conf_d_location }}"
+    state:                   directory
+
 - name:                     "Render {{ __customizer_conf_location }}"
   template:
     src:                    "{{ __customizer_conf_template }}"

--- a/roles/third_party/nginx-install/tasks/download_and_build_nginx.yml
+++ b/roles/third_party/nginx-install/tasks/download_and_build_nginx.yml
@@ -1,0 +1,84 @@
+---
+  - name:                   Check if NGINX is running
+    shell:
+      cmd:                  "nginx -t"
+    register:               nginx_test_output
+    ignore_errors: true
+
+  - name:                   Is NGINX already installed?
+    debug:                  var=nginx_test_output.stderr
+
+  - name:                   Download NGINX
+    unarchive:
+      src:                  "{{ __nginx_url }}"
+      dest:                 "/tmp"
+      remote_src:           yes
+    when:                   nginx_test_output.rc != 0
+
+  - name:                   Download headers-more-nginx-module
+    unarchive:
+      src:                  "{{ __nginx_headers_more_url }}"
+      dest:                 "/tmp"
+      remote_src:           yes
+    when:                   nginx_test_output.rc != 0
+
+  - name:                   Create logs folder
+    file:
+      path:                  "{{ __nginx_logs_dir }}"
+      state:                directory
+      mode:                 '0755'
+    when:                   nginx_test_output.rc != 0
+
+  - name:                   Create user to run NGINX if not exists
+    user:
+      name:                 nginx
+      state:                present
+      system:               yes
+    when:                   nginx_test_output.rc != 0
+    
+  - name:                   Add the headers-more-nginx-module module
+    shell:
+      chdir:                "{{ __nginx_download_dir }}"
+      cmd:                  "./configure --conf-path={{ __nginx_conf_location }} --with-http_ssl_module --with-http_stub_status_module --prefix={{ __nginx_install_dir }} --sbin-path={{ __nginx_exec_path }} --with-cc-opt=\"-I /usr/include/pcre\" --add-module={{ __nginx_headers_more_version_download_dir }}"
+    register:               nginx_configure_output
+    become:                 true
+    failed_when:            nginx_configure_output.rc != 0
+    when:                   nginx_test_output.rc != 0
+
+  - name:                   Compile NGINX from source
+    shell:
+      chdir:                "{{ __nginx_download_dir }}"
+      cmd:                  make
+    register:               nginx_make_output
+    failed_when:            nginx_make_output.rc != 0
+    when:                   nginx_test_output.rc != 0
+
+  - name:                   Install NGINX
+    shell:
+      chdir:                "{{ __nginx_download_dir }}"
+      cmd:                  make install
+    register:               nginx_make_install_output
+    become:                 true
+    failed_when:            nginx_make_install_output.rc != 0
+    when:                   nginx_test_output.rc != 0
+
+  - name:                   "Render {{ __nginx_service_location }}"
+    template:
+      src:                  "{{ __nginx_service_template }}"
+      dest:                 "{{ __nginx_service_location }}"
+    when:                   nginx_test_output.rc != 0
+
+  - name:                   Enable and start nginx service
+    systemd:
+      name:                 nginx
+      enabled:              yes
+    when:                   nginx_test_output.rc != 0
+
+  - name:                   Clean up installation folder
+    file:
+      path:                 "{{ item }}"
+      state:                absent
+    with_items:
+      - "{{ __nginx_download_dir }}"
+      - "{{ __nginx_headers_more_version_download_dir }}"
+    when:                   nginx_test_output.rc != 0

--- a/roles/third_party/nginx-install/tasks/install_nginx.yml
+++ b/roles/third_party/nginx-install/tasks/install_nginx.yml
@@ -3,13 +3,18 @@
     name:                   nginx
     state:                  latest
     allow_downgrade:        yes
+  when:                     not __build_nginx|bool
+
+- name:                     Build and Install nginx
+  include_tasks:            download_and_build_nginx.yml
+  when:                     __build_nginx|bool
 
 - name:                     Create Nginx folders
   file:
     path:                   "{{ item }}"
     state:                  directory
   with_items:
-   - "/etc/nginx/ssl"
+   - "{{ __nginx_install_dir }}/ssl"
 
 - name:                     Apply nginx.conf
   template:

--- a/roles/third_party/nginx-install/tasks/setup_os.yml
+++ b/roles/third_party/nginx-install/tasks/setup_os.yml
@@ -6,7 +6,7 @@
     dist:                   "centos"
     version:                "{{ ansible_distribution_major_version }}"
   when:
-   - ansible_facts['distribution'] == "CentOS"
+   - ansible_facts['distribution'] == "CentOS" and not __build_nginx|bool
 
 - name:                     Apply repository for RHEL
   template:
@@ -16,9 +16,16 @@
     dist:                   "rhel"
     version:                "{{ ansible_distribution_major_version }}"
   when:
-   - ansible_facts['distribution'] in ['RedHat', 'AlmaLinux', 'Rocky']
+   - ansible_facts['distribution'] in ['RedHat', 'AlmaLinux', 'Rocky'] and not __build_nginx|bool
 
-- name:                     Install prerequisits for semanage
+- name:                     Install prerequisites if building NGINX
+  package:
+    name:                   ['gcc', "pcre-devel", "openssl-devel", "zlib-devel"]
+    state:                  present
+  when:
+    - __build_nginx|bool
+
+- name:                     Install prerequisites for semanage
   package:
     name:                   "{{ item }}"
     state:                  present

--- a/roles/third_party/nginx-install/templates/customizer.conf.j2
+++ b/roles/third_party/nginx-install/templates/customizer.conf.j2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks:False
 proxy_redirect          off;
 proxy_set_header        Host            $host;
 proxy_set_header        X-Real-IP       $remote_addr;
@@ -26,6 +27,11 @@ server {
 
         proxy_ssl_session_reuse on;
         proxy_ssl_protocols TLSv1.2;
+
+        server_tokens off;
+        {% if __build_nginx | bool %}
+        more_clear_headers Server;
+        {% endif %}
 
         rewrite_log on;
 
@@ -83,6 +89,11 @@ server {
     proxy_cache_bypass $http_cache_control;
     proxy_ignore_headers "Set-Cookie";
     add_header X-Proxy-Cache $upstream_cache_status;
+
+    server_tokens off;
+    {% if __build_nginx | bool %}
+    more_clear_headers Server;
+    {% endif %}
 
     location /basic_status {
         stub_status;

--- a/roles/third_party/nginx-install/templates/nginx.conf.j2
+++ b/roles/third_party/nginx-install/templates/nginx.conf.j2
@@ -1,6 +1,6 @@
-user nginx;
+user {{ __nginx_user }};
 worker_processes auto;
-error_log /var/log/nginx/error.log;
+error_log {{ __nginx_logs_dir }}/error.log;
 pid /run/nginx.pid;
 
 events {
@@ -12,7 +12,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log {{ __nginx_logs_dir }}/access.log  main;
 
     sendfile            on;
     tcp_nopush          on;
@@ -20,8 +20,8 @@ http {
     keepalive_timeout   65;
     types_hash_max_size 2048;
 
-    include             /etc/nginx/mime.types;
+    include             {{ __nginx_install_dir }}/mime.types;
     default_type        application/octet-stream;
 
-    include /etc/nginx/conf.d/*.conf;
+    include {{ __nginx_install_dir }}/conf.d/*.conf;
 }

--- a/roles/third_party/nginx-install/templates/nginx.service.j2
+++ b/roles/third_party/nginx-install/templates/nginx.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=The NGINX HTTP and reverse proxy server
+After=syslog.target network-online.target remote-fs.target nss-lookup.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+PIDFile={{ __nginx_pid_loc }}
+ExecStartPre={{ __nginx_exec_path }} -t
+ExecStart={{ __nginx_exec_path }}
+ExecReload={{ __nginx_exec_path }} -s reload
+ExecStop=/bin/kill -s QUIT $MAINPID
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/third_party/nginx-install/vars/main.yml
+++ b/roles/third_party/nginx-install/vars/main.yml
@@ -1,8 +1,29 @@
 ---
-__conf_d_location:              "/etc/nginx/conf.d"
+# build nginx params
+__nginx_install_dir:            "{{ nginx_install_dir | default('/etc/nginx') }}"
+__nginx_logs_dir:               "{{ nginx_logs_dir | default('/var/log/nginx') }}"
+__nginx_pid_loc:                "{{ nginx_pid_loc | default('/run/nginx.pid') }}"
+__nginx_exec_path:              "{{ nginx_exec_path | default('/usr/sbin/nginx') }}"
+__nginx_user:                   "{{ nginx_user | default('nginx') }}"
+
+__build_nginx:                  "{{ build_nginx | default(true) }}"
+__nginx_version:                "1.24.0"
+__nginx_url:                    "http://nginx.org/download/nginx-{{ __nginx_version }}.tar.gz"
+__nginx_download_dir:           "/tmp/nginx-{{ __nginx_version }}"
+
+__nginx_headers_more_version:   "0.37"
+__nginx_headers_more_url:       "https://github.com/openresty/headers-more-nginx-module/archive/refs/tags/v{{ __nginx_headers_more_version }}.tar.gz"
+__nginx_headers_more_version_download_dir:           "/tmp/headers-more-nginx-module-{{ __nginx_headers_more_version }}"
+
+__nginx_service_template:       "nginx.service.j2"
+__nginx_service_location:       "{{ nginx_service_location | default('/etc/systemd/system/nginx.service') }}"
+
+
+# common nginx params
+__conf_d_location:              "{{ __nginx_install_dir }}/conf.d"
 
 __nginx_conf_template:          "nginx.conf.j2"
-__nginx_conf_location:          "/etc/nginx/nginx.conf"
+__nginx_conf_location:          "{{ __nginx_install_dir }}/nginx.conf"
 
 __nginx_certbot_production:     "{{ nginx_certbot_production | default(false) }}"
 
@@ -17,9 +38,9 @@ __packages_location:            "{{ packages_location | default('/data/packages'
 __setup_file_server:            "{{ setup_file_server | default('false') }}"
 __setup_customizer:             "{{ setup_customizer | default('true') }}"
 
-__nginx_crt_file:               "/etc/nginx/ssl/{{ inventory_hostname }}.crt"
-__nginx_key_file:               "/etc/nginx/ssl/{{ inventory_hostname }}.key"
-__nginx_cnf_location:           "/etc/nginx/ssl/{{ inventory_hostname }}.cnf"
+__nginx_crt_file:               "{{ __nginx_install_dir }}/ssl/{{ inventory_hostname }}.crt"
+__nginx_key_file:               "{{ __nginx_install_dir }}/ssl/{{ inventory_hostname }}.key"
+__nginx_cnf_location:           "{{ __nginx_install_dir }}/ssl/{{ inventory_hostname }}.cnf"
 __nginx_cnf_template:           "cert.cnf.j2"
 
 __mw_proxy_address:             "{{ load_balancer_dns | default('localhost') }}"

--- a/roles/third_party/tiny-editors-install/tasks/download_tiny_editors.yml
+++ b/roles/third_party/tiny-editors-install/tasks/download_tiny_editors.yml
@@ -13,6 +13,7 @@
     src:                 "{{ __download_location }}/{{ __package_name }}"
     dest:                "{{ __extraction_folder }}"
     remote_src:          yes
+    validate_certs:      false
   register: download_and_unpack_tinyeditors
   until: download_and_unpack_tinyeditors is succeeded
   retries: 3


### PR DESCRIPTION
- Kubernetes 1.29
- containerd 1.6.26-3.1
- nginx install will now build with the headers-more-nginx-module to allow the removal of server information from header.  Set `build_nginx` to false to install from package manager instead without the module.
